### PR TITLE
feat: add init-workspace command for multi-agent friendly workspace setup

### DIFF
--- a/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md
+++ b/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md
@@ -1,0 +1,41 @@
+# Documentation Log - Bob - 2026-05-02
+
+## Loop 00001 - 2026-05-02 00:00
+
+### Documentation Added
+
+#### DOC-001: `Settings` class
+- **Status:** IMPLEMENTED
+- **File:** `src/agent_skill_router/settings.py`
+- **Type:** Class
+- **Documentation Summary:**
+  - Description: Pydantic-settings config class; all settings via `SKILL_ROUTER_*` env vars; explains `providers_default` opt-in/opt-out pattern and nested delimiter convention
+  - Parameters: N/A (fields use `Field(description=...)`)
+  - Examples: Yes — two usage examples (disable all providers except Claude; add extra dir)
+- **Coverage Impact:** +estimated
+
+---
+
+#### DOC-002: `SlashCommand` type alias
+- **Status:** IMPLEMENTED
+- **File:** `src/agent_skill_router/agents/_base.py`
+- **Type:** Type alias
+- **Documentation Summary:**
+  - Description: Discriminated union of PromptSlashCommand | ToolSlashCommand | ResourceSlashCommand; documents all three variants and how the `type` field drives Pydantic deserialization
+  - Parameters: N/A
+  - Examples: No
+- **Coverage Impact:** +estimated
+
+---
+
+#### DOC-003: `ClaudeSetupProvider.config_path_workspace`
+- **Status:** IMPLEMENTED
+- **File:** `src/agent_skill_router/agents/claude.py`
+- **Type:** Method
+- **Documentation Summary:**
+  - Description: Returns workspace-scoped Claude MCP config path (`<cwd>/.claude/mcp.json`)
+  - Parameters: None
+  - Examples: No
+- **Coverage Impact:** +estimated
+
+---

--- a/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md
+++ b/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md
@@ -39,3 +39,15 @@
 - **Coverage Impact:** +estimated
 
 ---
+
+#### DOC-004: `ClaudeSetupProvider.config_path_user`
+- **Status:** IMPLEMENTED
+- **File:** `src/agent_skill_router/agents/claude.py`
+- **Type:** Method
+- **Documentation Summary:**
+  - Description: Returns user-scoped Claude MCP config path (`~/.claude/mcp.json`)
+  - Parameters: None
+  - Examples: No
+- **Coverage Impact:** +estimated
+
+---

--- a/.maestro/tasks/LOOP_00001_GAPS.md
+++ b/.maestro/tasks/LOOP_00001_GAPS.md
@@ -1,187 +1,279 @@
----
-type: analysis
-title: Documentation Gaps - Loop 00001
-created: 2026-05-02
-tags:
-  - documentation
-  - coverage
-  - gaps
-related:
-  - '[[LOOP_00001_DOC_REPORT]]'
----
-
 # Documentation Gaps - Loop 00001
 
 ## Summary
-- **Total Gaps Found:** 8
-- **By Type:** 8 Functions, 0 Classes, 0 Types, 0 Modules
-- **By Visibility:** 1 Public API, 7 Internal API
+- **Total Gaps Found:** 12
+- **By Type:** 10 Functions/Methods, 1 Class, 1 Type Alias
+- **By Visibility:** 2 Public API, 8 Internal API, 2 Utility
+- **Overall Coverage:** 89.2% (target: 90%, gap: 0.8%)
+
+---
 
 ## Gap List
 
-### GAP-001: `build_mcp`
-- **File:** `src/agent_skill_router/server.py`
-- **Line:** 190
-- **Type:** Function
+### GAP-001: `Settings` class
+- **File:** `src/agent_skill_router/settings.py`
+- **Line:** 13
+- **Type:** Class
 - **Visibility:** PUBLIC API
-- **Complexity:** COMPLEX
-- **Current State:** No docs (has inline comments but no top-level docstring)
+- **Complexity:** MODERATE
+- **Current State:** No docs (fields documented via `Field(description=...)` but no class-level docstring)
 - **Why It Needs Docs:**
-  - Primary public entry point exported from `agent_skill_router.__init__`
-  - Called by `cli.py` and importable directly by library consumers
-  - Accepts two optional parameters whose interaction and defaults are non-obvious
-  - Returns a `FastMCP` instance — what it exposes is undocumented
+  - All configuration flows through this class; it is the primary extension point for operators
+  - Pydantic `Field` descriptions are not surfaced in `help()` or IDEs the same way as a docstring
+  - Class purpose, env var prefix (`SKILL_ROUTER_`), and configuration approach should be stated
 - **Signature:**
   ```
-  def build_mcp(settings: Settings | None = None, workspace_dir: Path | None = None) -> FastMCP
+  class Settings(BaseSettings)
   ```
 - **Documentation Needed:**
-  - [ ] Description
-  - [ ] Parameters (`settings`, `workspace_dir`)
-  - [ ] Return value (what the `FastMCP` instance exposes)
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
   - [ ] Examples
   - [ ] Error handling
 
 ---
 
-### GAP-002: `ClaudeAgentSetupProvider.list_prompts`
+### GAP-002: `SlashCommand` type alias
+- **File:** `src/agent_skill_router/agents/_base.py`
+- **Line:** 61
+- **Type:** Type alias
+- **Visibility:** PUBLIC API
+- **Complexity:** SIMPLE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - It is a discriminated union; callers need to know the three variants and how the `type` discriminator works
+- **Signature:**
+  ```
+  SlashCommand = Annotated[PromptSlashCommand | ToolSlashCommand | ResourceSlashCommand, Field(discriminator="type")]
+  ```
+- **Documentation Needed:**
+  - [x] Description
+  - [ ] Parameters
+  - [ ] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-003: `ClaudeProvider.config_path_workspace`
 - **File:** `src/agent_skill_router/agents/claude.py`
-- **Line:** 111
-- **Type:** Function
+- **Line:** 44
+- **Type:** Method
 - **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
+- **Complexity:** SIMPLE
 - **Current State:** No docs
 - **Why It Needs Docs:**
-  - Overrides abstract method from `AgentSetupProvider`; directory scanned (`.claude/commands/*.md`) is not obvious from the name alone
-  - Consistent one-liner docstring would match all other provider methods
+  - Overrides abstract base; semantic meaning of "workspace config path" differs per agent
+  - Returns `.claude/mcp.json` relative to `Path.cwd()`
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_workspace(self) -> Path
   ```
 - **Documentation Needed:**
-  - [ ] Description (mention `.claude/commands/*.md` path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
 
 ---
 
-### GAP-003: `CursorAgentSetupProvider.list_prompts`
+### GAP-004: `ClaudeProvider.config_path_user`
+- **File:** `src/agent_skill_router/agents/claude.py`
+- **Line:** 47
+- **Type:** Method
+- **Visibility:** INTERNAL API
+- **Complexity:** SIMPLE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Returns `~/.claude/mcp.json`; the user-level vs workspace distinction is significant
+- **Signature:**
+  ```
+  def config_path_user(self) -> Path
+  ```
+- **Documentation Needed:**
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-005: `CursorProvider.config_path_workspace`
 - **File:** `src/agent_skill_router/agents/cursor.py`
-- **Line:** 106
-- **Type:** Function
+- **Line:** 43
+- **Type:** Method
 - **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
+- **Complexity:** SIMPLE
 - **Current State:** No docs
 - **Why It Needs Docs:**
-  - Same pattern as GAP-002; scanned path is `.cursor/prompts/*.md`
+  - Same pattern as GAP-003; Cursor uses a different config path convention
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_workspace(self) -> Path
   ```
 - **Documentation Needed:**
-  - [ ] Description (mention `.cursor/prompts/*.md` path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
 
 ---
 
-### GAP-004: `GithubCopilotAgentSetupProvider.list_prompts`
-- **File:** `src/agent_skill_router/agents/github_copilot.py`
-- **Line:** 109
-- **Type:** Function
+### GAP-006: `CursorProvider.config_path_user`
+- **File:** `src/agent_skill_router/agents/cursor.py`
+- **Line:** 46
+- **Type:** Method
 - **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
+- **Complexity:** SIMPLE
 - **Current State:** No docs
 - **Why It Needs Docs:**
-  - Same pattern as GAP-002; scanned path is `.github/prompts/*.prompt.md`
+  - Same as GAP-004
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_user(self) -> Path
   ```
 - **Documentation Needed:**
-  - [ ] Description (mention `.github/prompts/*.prompt.md` path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
 
 ---
 
-### GAP-005: `OpencodeAgentSetupProvider.list_prompts`
-- **File:** `src/agent_skill_router/agents/opencode.py`
-- **Line:** 106
-- **Type:** Function
-- **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
-- **Current State:** No docs
-- **Why It Needs Docs:**
-  - Same pattern as GAP-002; scanned path is `.opencode/prompts/*.md`
-- **Signature:**
-  ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
-  ```
-- **Documentation Needed:**
-  - [ ] Description (mention `.opencode/prompts/*.md` path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
-
----
-
-### GAP-006: `GooseAgentSetupProvider.list_prompts`
-- **File:** `src/agent_skill_router/agents/goose.py`
-- **Line:** 171
-- **Type:** Function
-- **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
-- **Current State:** No docs
-- **Why It Needs Docs:**
-  - Same pattern as GAP-002; scanned directory for Goose-specific prompt files
-- **Signature:**
-  ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
-  ```
-- **Documentation Needed:**
-  - [ ] Description (mention scanned path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
-
----
-
-### GAP-007: `GeminiAgentSetupProvider.list_prompts`
+### GAP-007: `GeminiProvider.config_path_workspace`
 - **File:** `src/agent_skill_router/agents/gemini.py`
-- **Line:** 105
-- **Type:** Function
+- **Line:** 42
+- **Type:** Method
 - **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
+- **Complexity:** SIMPLE
 - **Current State:** No docs
 - **Why It Needs Docs:**
-  - Same pattern as GAP-002; scanned directory for Gemini-specific prompt files
+  - Same pattern as GAP-003
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_workspace(self) -> Path
   ```
 - **Documentation Needed:**
-  - [ ] Description (mention scanned path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
 
 ---
 
-### GAP-008: `CodexAgentSetupProvider.list_prompts`
-- **File:** `src/agent_skill_router/agents/codex.py`
-- **Line:** 141
-- **Type:** Function
+### GAP-008: `GeminiProvider.config_path_user`
+- **File:** `src/agent_skill_router/agents/gemini.py`
+- **Line:** 45
+- **Type:** Method
 - **Visibility:** INTERNAL API
-- **Complexity:** MODERATE
+- **Complexity:** SIMPLE
 - **Current State:** No docs
 - **Why It Needs Docs:**
-  - Same pattern as GAP-002; scanned directory for Codex-specific prompt files
+  - Same as GAP-004
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_user(self) -> Path
   ```
 - **Documentation Needed:**
-  - [ ] Description (mention scanned path)
-  - [ ] Parameters (`roots`)
-  - [ ] Return value
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-009: `GithubCopilotProvider.config_path_workspace`
+- **File:** `src/agent_skill_router/agents/github_copilot.py`
+- **Line:** 42
+- **Type:** Method
+- **Visibility:** INTERNAL API
+- **Complexity:** SIMPLE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-003
+- **Signature:**
+  ```
+  def config_path_workspace(self) -> Path
+  ```
+- **Documentation Needed:**
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-010: `GithubCopilotProvider.config_path_user`
+- **File:** `src/agent_skill_router/agents/github_copilot.py`
+- **Line:** 45
+- **Type:** Method
+- **Visibility:** INTERNAL API
+- **Complexity:** SIMPLE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same as GAP-004
+- **Signature:**
+  ```
+  def config_path_user(self) -> Path
+  ```
+- **Documentation Needed:**
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-011: `OpenCodeProvider.config_path_workspace`
+- **File:** `src/agent_skill_router/agents/opencode.py`
+- **Line:** 39
+- **Type:** Method
+- **Visibility:** INTERNAL API
+- **Complexity:** SIMPLE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-003
+- **Signature:**
+  ```
+  def config_path_workspace(self) -> Path
+  ```
+- **Documentation Needed:**
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-012: `OpenCodeProvider.config_path_user`
+- **File:** `src/agent_skill_router/agents/opencode.py`
+- **Line:** 42
+- **Type:** Method
+- **Visibility:** INTERNAL API
+- **Complexity:** SIMPLE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same as GAP-004
+- **Signature:**
+  ```
+  def config_path_user(self) -> Path
+  ```
+- **Documentation Needed:**
+  - [x] Description
+  - [ ] Parameters
+  - [x] Return value
+  - [ ] Examples
+  - [ ] Error handling
 
 ---
 
@@ -189,32 +281,50 @@ related:
 
 | Module | Gap Count | Types |
 |--------|-----------|-------|
-| `src/agent_skill_router/server.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/claude.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/cursor.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/github_copilot.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/opencode.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/goose.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/gemini.py` | 1 | 1 Function |
-| `src/agent_skill_router/agents/codex.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/claude.py` | 2 | 2 Methods |
+| `src/agent_skill_router/agents/cursor.py` | 2 | 2 Methods |
+| `src/agent_skill_router/agents/gemini.py` | 2 | 2 Methods |
+| `src/agent_skill_router/agents/github_copilot.py` | 2 | 2 Methods |
+| `src/agent_skill_router/agents/opencode.py` | 2 | 2 Methods |
+| `src/agent_skill_router/agents/_base.py` | 1 | 1 Type alias |
+| `src/agent_skill_router/settings.py` | 1 | 1 Class |
 
 ## Gaps by Type
 
-### Functions
+### Classes
 | Name | File | Visibility | Complexity |
 |------|------|------------|------------|
-| `build_mcp` | `src/agent_skill_router/server.py` | PUBLIC API | COMPLEX |
-| `ClaudeAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/claude.py` | INTERNAL API | MODERATE |
-| `CursorAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/cursor.py` | INTERNAL API | MODERATE |
-| `GithubCopilotAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/github_copilot.py` | INTERNAL API | MODERATE |
-| `OpencodeAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/opencode.py` | INTERNAL API | MODERATE |
-| `GooseAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/goose.py` | INTERNAL API | MODERATE |
-| `GeminiAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/gemini.py` | INTERNAL API | MODERATE |
-| `CodexAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/codex.py` | INTERNAL API | MODERATE |
+| `Settings` | `src/agent_skill_router/settings.py` | PUBLIC API | MODERATE |
+
+### Types/Interfaces
+| Name | File | Visibility | Complexity |
+|------|------|------------|------------|
+| `SlashCommand` | `src/agent_skill_router/agents/_base.py` | PUBLIC API | SIMPLE |
+
+### Methods
+| Name | File | Visibility | Complexity |
+|------|------|------------|------------|
+| `ClaudeProvider.config_path_workspace` | `src/agent_skill_router/agents/claude.py` | INTERNAL API | SIMPLE |
+| `ClaudeProvider.config_path_user` | `src/agent_skill_router/agents/claude.py` | INTERNAL API | SIMPLE |
+| `CursorProvider.config_path_workspace` | `src/agent_skill_router/agents/cursor.py` | INTERNAL API | SIMPLE |
+| `CursorProvider.config_path_user` | `src/agent_skill_router/agents/cursor.py` | INTERNAL API | SIMPLE |
+| `GeminiProvider.config_path_workspace` | `src/agent_skill_router/agents/gemini.py` | INTERNAL API | SIMPLE |
+| `GeminiProvider.config_path_user` | `src/agent_skill_router/agents/gemini.py` | INTERNAL API | SIMPLE |
+| `GithubCopilotProvider.config_path_workspace` | `src/agent_skill_router/agents/github_copilot.py` | INTERNAL API | SIMPLE |
+| `GithubCopilotProvider.config_path_user` | `src/agent_skill_router/agents/github_copilot.py` | INTERNAL API | SIMPLE |
+| `OpenCodeProvider.config_path_workspace` | `src/agent_skill_router/agents/opencode.py` | INTERNAL API | SIMPLE |
+| `OpenCodeProvider.config_path_user` | `src/agent_skill_router/agents/opencode.py` | INTERNAL API | SIMPLE |
 
 ## Related Exports
 
 Exports that should be documented together:
 
-- **Group A:** All 7 `list_prompts` overrides in agent provider files — identical signatures, same pattern; document the ABC method in `_base.py` first, then add one-liners in each override mentioning the specific directory scanned.
-- **Group B:** `build_mcp` in `server.py` — standalone, highest priority as the primary public API.
+- **Group A:** `config_path_workspace` and `config_path_user` across all 5 agent providers — identical pattern, should use the same docstring template
+- **Group B:** `Settings` class — standalone, highest priority
+- **Group C:** `SlashCommand` type alias — should be documented alongside `PromptSlashCommand`, `ToolSlashCommand`, `ResourceSlashCommand` in `_base.py`
+
+## Recommended Fix Order
+
+1. `Settings` class docstring — highest visibility, single change
+2. `SlashCommand` type alias docstring — small, high clarity gain
+3. `config_path_workspace` / `config_path_user` in all 5 agents — use a shared one-liner template: `"Return the path to the MCP config file for workspace/user-level installation."`

--- a/.maestro/tasks/LOOP_00001_GAPS.md
+++ b/.maestro/tasks/LOOP_00001_GAPS.md
@@ -1,0 +1,220 @@
+---
+type: analysis
+title: Documentation Gaps - Loop 00001
+created: 2026-05-02
+tags:
+  - documentation
+  - coverage
+  - gaps
+related:
+  - '[[LOOP_00001_DOC_REPORT]]'
+---
+
+# Documentation Gaps - Loop 00001
+
+## Summary
+- **Total Gaps Found:** 8
+- **By Type:** 8 Functions, 0 Classes, 0 Types, 0 Modules
+- **By Visibility:** 1 Public API, 7 Internal API
+
+## Gap List
+
+### GAP-001: `build_mcp`
+- **File:** `src/agent_skill_router/server.py`
+- **Line:** 190
+- **Type:** Function
+- **Visibility:** PUBLIC API
+- **Complexity:** COMPLEX
+- **Current State:** No docs (has inline comments but no top-level docstring)
+- **Why It Needs Docs:**
+  - Primary public entry point exported from `agent_skill_router.__init__`
+  - Called by `cli.py` and importable directly by library consumers
+  - Accepts two optional parameters whose interaction and defaults are non-obvious
+  - Returns a `FastMCP` instance — what it exposes is undocumented
+- **Signature:**
+  ```
+  def build_mcp(settings: Settings | None = None, workspace_dir: Path | None = None) -> FastMCP
+  ```
+- **Documentation Needed:**
+  - [ ] Description
+  - [ ] Parameters (`settings`, `workspace_dir`)
+  - [ ] Return value (what the `FastMCP` instance exposes)
+  - [ ] Examples
+  - [ ] Error handling
+
+---
+
+### GAP-002: `ClaudeAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/claude.py`
+- **Line:** 111
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Overrides abstract method from `AgentSetupProvider`; directory scanned (`.claude/commands/*.md`) is not obvious from the name alone
+  - Consistent one-liner docstring would match all other provider methods
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention `.claude/commands/*.md` path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+### GAP-003: `CursorAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/cursor.py`
+- **Line:** 106
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-002; scanned path is `.cursor/prompts/*.md`
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention `.cursor/prompts/*.md` path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+### GAP-004: `GithubCopilotAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/github_copilot.py`
+- **Line:** 109
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-002; scanned path is `.github/prompts/*.prompt.md`
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention `.github/prompts/*.prompt.md` path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+### GAP-005: `OpencodeAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/opencode.py`
+- **Line:** 106
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-002; scanned path is `.opencode/prompts/*.md`
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention `.opencode/prompts/*.md` path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+### GAP-006: `GooseAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/goose.py`
+- **Line:** 171
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-002; scanned directory for Goose-specific prompt files
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention scanned path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+### GAP-007: `GeminiAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/gemini.py`
+- **Line:** 105
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-002; scanned directory for Gemini-specific prompt files
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention scanned path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+### GAP-008: `CodexAgentSetupProvider.list_prompts`
+- **File:** `src/agent_skill_router/agents/codex.py`
+- **Line:** 141
+- **Type:** Function
+- **Visibility:** INTERNAL API
+- **Complexity:** MODERATE
+- **Current State:** No docs
+- **Why It Needs Docs:**
+  - Same pattern as GAP-002; scanned directory for Codex-specific prompt files
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Needed:**
+  - [ ] Description (mention scanned path)
+  - [ ] Parameters (`roots`)
+  - [ ] Return value
+
+---
+
+## Gaps by Module
+
+| Module | Gap Count | Types |
+|--------|-----------|-------|
+| `src/agent_skill_router/server.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/claude.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/cursor.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/github_copilot.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/opencode.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/goose.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/gemini.py` | 1 | 1 Function |
+| `src/agent_skill_router/agents/codex.py` | 1 | 1 Function |
+
+## Gaps by Type
+
+### Functions
+| Name | File | Visibility | Complexity |
+|------|------|------------|------------|
+| `build_mcp` | `src/agent_skill_router/server.py` | PUBLIC API | COMPLEX |
+| `ClaudeAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/claude.py` | INTERNAL API | MODERATE |
+| `CursorAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/cursor.py` | INTERNAL API | MODERATE |
+| `GithubCopilotAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/github_copilot.py` | INTERNAL API | MODERATE |
+| `OpencodeAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/opencode.py` | INTERNAL API | MODERATE |
+| `GooseAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/goose.py` | INTERNAL API | MODERATE |
+| `GeminiAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/gemini.py` | INTERNAL API | MODERATE |
+| `CodexAgentSetupProvider.list_prompts` | `src/agent_skill_router/agents/codex.py` | INTERNAL API | MODERATE |
+
+## Related Exports
+
+Exports that should be documented together:
+
+- **Group A:** All 7 `list_prompts` overrides in agent provider files — identical signatures, same pattern; document the ABC method in `_base.py` first, then add one-liners in each override mentioning the specific directory scanned.
+- **Group B:** `build_mcp` in `server.py` — standalone, highest priority as the primary public API.

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -77,7 +77,8 @@
 ---
 
 ### DOC-004: `ClaudeProvider.config_path_user`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/claude.py`
 - **Gap ID:** GAP-004
 - **Type:** Method
@@ -87,12 +88,12 @@
   ```
   def config_path_user(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the Claude MCP config file for user-level installation (`~/.claude/mcp.json`)
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — user-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the Claude MCP config file for user-level installation (`~/.claude/mcp.json`)
+  - [x] Parameters: None
+  - [x] Returns: `Path` — user-scoped config path
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -1,0 +1,206 @@
+---
+type: analysis
+title: Documentation Plan - Loop 00001
+created: 2026-05-02
+tags:
+  - documentation
+  - plan
+  - coverage
+related:
+  - '[[LOOP_00001_GAPS]]'
+  - '[[LOOP_00001_DOC_REPORT]]'
+---
+
+# Documentation Plan - Loop 00001
+
+## Summary
+- **Total Gaps:** 8
+- **Auto-Document (PENDING):** 8
+- **Needs Context:** 0
+- **Won't Do:** 0
+
+## Current Coverage: 87.5%
+## Target Coverage: 90%
+## Estimated Post-Loop Coverage: 92.7%
+
+---
+
+## PENDING - Ready for Auto-Documentation
+
+### DOC-001: `build_mcp`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/server.py`
+- **Gap ID:** GAP-001
+- **Type:** Function
+- **Visibility:** PUBLIC
+- **Importance:** CRITICAL
+- **Signature:**
+  ```
+  def build_mcp(settings: Settings | None = None, workspace_dir: Path | None = None) -> FastMCP
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Primary public entry point; builds and returns a configured FastMCP server instance
+  - [ ] Parameters: `settings` (optional Settings override), `workspace_dir` (optional workspace path override)
+  - [ ] Returns: Configured `FastMCP` instance exposing skill resources and tools
+  - [ ] Examples: Yes — show basic usage as library consumer
+  - [ ] Errors: Document behavior when settings are invalid or dirs don't exist
+
+### DOC-002: `ClaudeAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/claude.py`
+- **Gap ID:** GAP-002
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans `.claude/commands/*.md` under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+### DOC-003: `CursorAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/cursor.py`
+- **Gap ID:** GAP-003
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans `.cursor/prompts/*.md` under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+### DOC-004: `GithubCopilotAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/github_copilot.py`
+- **Gap ID:** GAP-004
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans `.github/prompts/*.prompt.md` under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+### DOC-005: `OpencodeAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/opencode.py`
+- **Gap ID:** GAP-005
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans `.opencode/prompts/*.md` under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+### DOC-006: `GooseAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/goose.py`
+- **Gap ID:** GAP-006
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans Goose-specific prompt directories under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+### DOC-007: `GeminiAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/gemini.py`
+- **Gap ID:** GAP-007
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans Gemini-specific prompt directories under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+### DOC-008: `CodexAgentSetupProvider.list_prompts`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/codex.py`
+- **Gap ID:** GAP-008
+- **Type:** Function
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Scans Codex-specific prompt directories under each root for slash command definitions
+  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
+  - [ ] Returns: List of `SlashCommand` objects discovered
+  - [ ] Examples: No
+  - [ ] Errors: No
+
+---
+
+## PENDING - NEEDS CONTEXT
+
+_(None)_
+
+---
+
+## WON'T DO
+
+_(None)_
+
+---
+
+## Documentation Order
+
+Recommended sequence based on visibility and dependencies:
+
+1. **DOC-001** - `build_mcp` (PUBLIC, CRITICAL — primary library entry point; document first)
+2. **DOC-002** - `ClaudeAgentSetupProvider.list_prompts` (INTERNAL, HIGH — reference impl for group)
+3. **DOC-003** - `CursorAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+4. **DOC-004** - `GithubCopilotAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+5. **DOC-005** - `OpencodeAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+6. **DOC-006** - `GooseAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+7. **DOC-007** - `GeminiAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+8. **DOC-008** - `CodexAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+
+## Related Documentation
+
+Exports that should be documented together for consistency:
+
+- **Group A:** DOC-002 through DOC-008 — all `list_prompts` overrides across agent providers; identical signatures, one-liner docstrings mentioning the specific directory each scans
+- **Group B:** DOC-001 — `build_mcp` standalone; highest priority as the primary public API

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -104,7 +104,8 @@ related:
   - [x] Errors: No
 
 ### DOC-005: `OpencodeAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001 (iteration 2)
 - **File:** `src/agent_skill_router/agents/opencode.py`
 - **Gap ID:** GAP-005
 - **Type:** Function
@@ -114,15 +115,16 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans `.opencode/prompts/*.md` under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Scans `.opencode/commands/*.md` under each root for slash command definitions
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
+  - [x] Examples: No
+  - [x] Errors: No
 
 ### DOC-006: `GooseAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001 (iteration 1 — already had docstring)
 - **File:** `src/agent_skill_router/agents/goose.py`
 - **Gap ID:** GAP-006
 - **Type:** Function
@@ -132,15 +134,16 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans Goose-specific prompt directories under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Reads recipes from `.goose/recipes/*.yaml` under each root
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by title
+  - [x] Examples: No
+  - [x] Errors: No
 
 ### DOC-007: `GeminiAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001 (iteration 2)
 - **File:** `src/agent_skill_router/agents/gemini.py`
 - **Gap ID:** GAP-007
 - **Type:** Function
@@ -150,15 +153,16 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans Gemini-specific prompt directories under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Scans `.gemini/commands/**/*.toml` under each root for slash command definitions
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by colon-joined path name
+  - [x] Examples: No
+  - [x] Errors: No
 
 ### DOC-008: `CodexAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001 (iteration 2)
 - **File:** `src/agent_skill_router/agents/codex.py`
 - **Gap ID:** GAP-008
 - **Type:** Function
@@ -168,12 +172,12 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans Codex-specific prompt directories under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Scans `.codex/prompts/*.md` under each root for slash command definitions
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
+  - [x] Examples: No
+  - [x] Errors: No
 
 ---
 

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -98,7 +98,8 @@
 ---
 
 ### DOC-005: `CursorProvider.config_path_workspace`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/cursor.py`
 - **Gap ID:** GAP-005
 - **Type:** Method
@@ -108,17 +109,18 @@
   ```
   def config_path_workspace(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the Cursor MCP config file for workspace-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — workspace-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the Cursor MCP config file for workspace-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``<cwd>/.cursor/mcp.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-006: `CursorProvider.config_path_user`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/cursor.py`
 - **Gap ID:** GAP-006
 - **Type:** Method
@@ -128,17 +130,18 @@
   ```
   def config_path_user(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the Cursor MCP config file for user-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — user-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the Cursor MCP config file for user-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``~/.cursor/mcp.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-007: `GeminiProvider.config_path_workspace`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/gemini.py`
 - **Gap ID:** GAP-007
 - **Type:** Method
@@ -148,17 +151,18 @@
   ```
   def config_path_workspace(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the Gemini MCP config file for workspace-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — workspace-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the Gemini CLI MCP config file for workspace-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``<cwd>/.gemini/settings.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-008: `GeminiProvider.config_path_user`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/gemini.py`
 - **Gap ID:** GAP-008
 - **Type:** Method
@@ -168,17 +172,18 @@
   ```
   def config_path_user(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the Gemini MCP config file for user-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — user-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the Gemini CLI MCP config file for user-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``~/.gemini/settings.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-009: `GithubCopilotProvider.config_path_workspace`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/github_copilot.py`
 - **Gap ID:** GAP-009
 - **Type:** Method
@@ -188,17 +193,18 @@
   ```
   def config_path_workspace(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the GitHub Copilot MCP config file for workspace-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — workspace-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the GitHub Copilot MCP config file for workspace-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``<cwd>/.vscode/mcp.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-010: `GithubCopilotProvider.config_path_user`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/github_copilot.py`
 - **Gap ID:** GAP-010
 - **Type:** Method
@@ -208,17 +214,18 @@
   ```
   def config_path_user(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the GitHub Copilot MCP config file for user-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — user-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the GitHub Copilot MCP config file for user-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``~/.vscode/mcp.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-011: `OpenCodeProvider.config_path_workspace`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/opencode.py`
 - **Gap ID:** GAP-011
 - **Type:** Method
@@ -228,17 +235,18 @@
   ```
   def config_path_workspace(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the OpenCode MCP config file for workspace-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — workspace-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the OpenCode MCP config file for workspace-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``<cwd>/.opencode/mcp.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 
 ### DOC-012: `OpenCodeProvider.config_path_user`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/opencode.py`
 - **Gap ID:** GAP-012
 - **Type:** Method
@@ -248,12 +256,12 @@
   ```
   def config_path_user(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the OpenCode MCP config file for user-level installation
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — user-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the OpenCode MCP config file for user-level installation
+  - [x] Parameters: None
+  - [x] Returns: `Path` — ``~/.config/opencode/opencode.json``
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -66,7 +66,8 @@ related:
   - [x] Errors: No
 
 ### DOC-003: `CursorAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/cursor.py`
 - **Gap ID:** GAP-003
 - **Type:** Function
@@ -76,12 +77,12 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans `.cursor/prompts/*.md` under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Scans `.cursor/rules/*.mdc` and `*.md` under each root for rule/prompt definitions
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
+  - [x] Examples: No
+  - [x] Errors: No
 
 ### DOC-004: `GithubCopilotAgentSetupProvider.list_prompts`
 - **Status:** `PENDING`

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -47,7 +47,8 @@ related:
   - [x] Errors: Documented workspace resolution fallback behaviour
 
 ### DOC-002: `ClaudeAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/claude.py`
 - **Gap ID:** GAP-002
 - **Type:** Function
@@ -57,12 +58,12 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans `.claude/commands/*.md` under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Scans `.claude/commands/*.md` under each root for slash command definitions
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, one per `.md` file
+  - [x] Examples: No
+  - [x] Errors: No
 
 ### DOC-003: `CursorAgentSetupProvider.list_prompts`
 - **Status:** `PENDING`

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -15,7 +15,8 @@
 ## PENDING - Ready for Auto-Documentation
 
 ### DOC-001: `Settings` class
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/settings.py`
 - **Gap ID:** GAP-001
 - **Type:** Class
@@ -25,12 +26,11 @@
   ```
   class Settings(BaseSettings)
   ```
-- **Documentation Plan:**
-  - [ ] Description: Pydantic-settings configuration class for all agent-skill-router options; all settings are controlled via `SKILL_ROUTER_*` env vars
-  - [ ] Parameters: N/A (fields documented via `Field(description=...)`)
-  - [ ] Returns: N/A
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description
+  - [x] Parameters (N/A — fields use Field(description=...))
+  - [x] Returns (N/A)
+  - [x] Example
 
 ---
 

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -85,7 +85,8 @@ related:
   - [x] Errors: No
 
 ### DOC-004: `GithubCopilotAgentSetupProvider.list_prompts`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/github_copilot.py`
 - **Gap ID:** GAP-004
 - **Type:** Function
@@ -95,12 +96,12 @@ related:
   ```
   def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Scans `.github/prompts/*.prompt.md` under each root for slash command definitions
-  - [ ] Parameters: `roots` (list of base directories to scan; defaults to configured roots if None)
-  - [ ] Returns: List of `SlashCommand` objects discovered
-  - [ ] Examples: No
-  - [ ] Errors: No
+- **Documentation Added:**
+  - [x] Description: Scans `.github/prompts/*.prompt.md` under each root for slash command definitions
+  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
+  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
+  - [x] Examples: No
+  - [x] Errors: No
 
 ### DOC-005: `OpencodeAgentSetupProvider.list_prompts`
 - **Status:** `PENDING`

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -56,7 +56,8 @@
 ---
 
 ### DOC-003: `ClaudeProvider.config_path_workspace`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/claude.py`
 - **Gap ID:** GAP-003
 - **Type:** Method
@@ -66,12 +67,12 @@
   ```
   def config_path_workspace(self) -> Path
   ```
-- **Documentation Plan:**
-  - [ ] Description: Return the path to the Claude MCP config file for workspace-level installation (`.claude/mcp.json` relative to `Path.cwd()`)
-  - [ ] Parameters: None
-  - [ ] Returns: `Path` — workspace-scoped config path
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Return the path to the Claude MCP config file for workspace-level installation (`.claude/mcp.json` relative to `Path.cwd()`)
+  - [x] Parameters: None
+  - [x] Returns: `Path` — workspace-scoped config path
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -1,195 +1,268 @@
----
-type: analysis
-title: Documentation Plan - Loop 00001
-created: 2026-05-02
-tags:
-  - documentation
-  - plan
-  - coverage
-related:
-  - '[[LOOP_00001_GAPS]]'
-  - '[[LOOP_00001_DOC_REPORT]]'
----
-
 # Documentation Plan - Loop 00001
 
 ## Summary
-- **Total Gaps:** 8
-- **Auto-Document (PENDING):** 8
+- **Total Gaps:** 12
+- **Auto-Document (PENDING):** 12
 - **Needs Context:** 0
 - **Won't Do:** 0
 
-## Current Coverage: 87.5%
+## Current Coverage: 89.2%
 ## Target Coverage: 90%
-## Estimated Post-Loop Coverage: 92.7%
+## Estimated Post-Loop Coverage: 90.2%
 
 ---
 
 ## PENDING - Ready for Auto-Documentation
 
-### DOC-001: `build_mcp`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001
-- **File:** `src/agent_skill_router/server.py`
+### DOC-001: `Settings` class
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/settings.py`
 - **Gap ID:** GAP-001
-- **Type:** Function
+- **Type:** Class
 - **Visibility:** PUBLIC
 - **Importance:** CRITICAL
 - **Signature:**
   ```
-  def build_mcp(settings: Settings | None = None, workspace_dir: Path | None = None) -> FastMCP
+  class Settings(BaseSettings)
   ```
-- **Documentation Added:**
-  - [x] Description: Primary public entry point; builds and returns a configured FastMCP server instance
-  - [x] Parameters: `settings` (optional Settings override), `workspace_dir` (optional workspace path override)
-  - [x] Returns: Configured `FastMCP` instance exposing skill resources and tools
-  - [x] Examples: Yes — basic usage and settings-override example
-  - [x] Errors: Documented workspace resolution fallback behaviour
+- **Documentation Plan:**
+  - [ ] Description: Pydantic-settings configuration class for all agent-skill-router options; all settings are controlled via `SKILL_ROUTER_*` env vars
+  - [ ] Parameters: N/A (fields documented via `Field(description=...)`)
+  - [ ] Returns: N/A
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-002: `ClaudeAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001
-- **File:** `src/agent_skill_router/agents/claude.py`
+---
+
+### DOC-002: `SlashCommand` type alias
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/_base.py`
 - **Gap ID:** GAP-002
-- **Type:** Function
-- **Visibility:** INTERNAL
+- **Type:** Type alias
+- **Visibility:** PUBLIC
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  SlashCommand = Annotated[PromptSlashCommand | ToolSlashCommand | ResourceSlashCommand, Field(discriminator="type")]
   ```
-- **Documentation Added:**
-  - [x] Description: Scans `.claude/commands/*.md` under each root for slash command definitions
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, one per `.md` file
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Discriminated union of the three slash-command variants; the `type` field determines which variant is in use
+  - [ ] Parameters: N/A
+  - [ ] Returns: N/A
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-003: `CursorAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001
-- **File:** `src/agent_skill_router/agents/cursor.py`
+---
+
+### DOC-003: `ClaudeProvider.config_path_workspace`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/claude.py`
 - **Gap ID:** GAP-003
-- **Type:** Function
+- **Type:** Method
 - **Visibility:** INTERNAL
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_workspace(self) -> Path
   ```
-- **Documentation Added:**
-  - [x] Description: Scans `.cursor/rules/*.mdc` and `*.md` under each root for rule/prompt definitions
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the Claude MCP config file for workspace-level installation (`.claude/mcp.json` relative to `Path.cwd()`)
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — workspace-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-004: `GithubCopilotAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001
-- **File:** `src/agent_skill_router/agents/github_copilot.py`
+---
+
+### DOC-004: `ClaudeProvider.config_path_user`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/claude.py`
 - **Gap ID:** GAP-004
-- **Type:** Function
+- **Type:** Method
 - **Visibility:** INTERNAL
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_user(self) -> Path
   ```
-- **Documentation Added:**
-  - [x] Description: Scans `.github/prompts/*.prompt.md` under each root for slash command definitions
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the Claude MCP config file for user-level installation (`~/.claude/mcp.json`)
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — user-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-005: `OpencodeAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001 (iteration 2)
-- **File:** `src/agent_skill_router/agents/opencode.py`
+---
+
+### DOC-005: `CursorProvider.config_path_workspace`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/cursor.py`
 - **Gap ID:** GAP-005
-- **Type:** Function
+- **Type:** Method
 - **Visibility:** INTERNAL
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_workspace(self) -> Path
   ```
-- **Documentation Added:**
-  - [x] Description: Scans `.opencode/commands/*.md` under each root for slash command definitions
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the Cursor MCP config file for workspace-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — workspace-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-006: `GooseAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001 (iteration 1 — already had docstring)
-- **File:** `src/agent_skill_router/agents/goose.py`
+---
+
+### DOC-006: `CursorProvider.config_path_user`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/cursor.py`
 - **Gap ID:** GAP-006
-- **Type:** Function
+- **Type:** Method
 - **Visibility:** INTERNAL
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_user(self) -> Path
   ```
-- **Documentation Added:**
-  - [x] Description: Reads recipes from `.goose/recipes/*.yaml` under each root
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by title
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the Cursor MCP config file for user-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — user-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-007: `GeminiAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001 (iteration 2)
+---
+
+### DOC-007: `GeminiProvider.config_path_workspace`
+- **Status:** `PENDING`
 - **File:** `src/agent_skill_router/agents/gemini.py`
 - **Gap ID:** GAP-007
-- **Type:** Function
+- **Type:** Method
 - **Visibility:** INTERNAL
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_workspace(self) -> Path
   ```
-- **Documentation Added:**
-  - [x] Description: Scans `.gemini/commands/**/*.toml` under each root for slash command definitions
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by colon-joined path name
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the Gemini MCP config file for workspace-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — workspace-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
-### DOC-008: `CodexAgentSetupProvider.list_prompts`
-- **Status:** `IMPLEMENTED`
-- **Implemented In:** Loop 00001 (iteration 2)
-- **File:** `src/agent_skill_router/agents/codex.py`
+---
+
+### DOC-008: `GeminiProvider.config_path_user`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/gemini.py`
 - **Gap ID:** GAP-008
-- **Type:** Function
+- **Type:** Method
 - **Visibility:** INTERNAL
 - **Importance:** HIGH
 - **Signature:**
   ```
-  def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]
+  def config_path_user(self) -> Path
   ```
-- **Documentation Added:**
-  - [x] Description: Scans `.codex/prompts/*.md` under each root for slash command definitions
-  - [x] Parameters: `roots` (list of base directories to scan; defaults to `[Path.cwd()]` if None)
-  - [x] Returns: List of `SlashCommand` objects discovered, de-duplicated by stem
-  - [x] Examples: No
-  - [x] Errors: No
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the Gemini MCP config file for user-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — user-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
+
+---
+
+### DOC-009: `GithubCopilotProvider.config_path_workspace`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/github_copilot.py`
+- **Gap ID:** GAP-009
+- **Type:** Method
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def config_path_workspace(self) -> Path
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the GitHub Copilot MCP config file for workspace-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — workspace-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
+
+---
+
+### DOC-010: `GithubCopilotProvider.config_path_user`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/github_copilot.py`
+- **Gap ID:** GAP-010
+- **Type:** Method
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def config_path_user(self) -> Path
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the GitHub Copilot MCP config file for user-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — user-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
+
+---
+
+### DOC-011: `OpenCodeProvider.config_path_workspace`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/opencode.py`
+- **Gap ID:** GAP-011
+- **Type:** Method
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def config_path_workspace(self) -> Path
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the OpenCode MCP config file for workspace-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — workspace-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
+
+---
+
+### DOC-012: `OpenCodeProvider.config_path_user`
+- **Status:** `PENDING`
+- **File:** `src/agent_skill_router/agents/opencode.py`
+- **Gap ID:** GAP-012
+- **Type:** Method
+- **Visibility:** INTERNAL
+- **Importance:** HIGH
+- **Signature:**
+  ```
+  def config_path_user(self) -> Path
+  ```
+- **Documentation Plan:**
+  - [ ] Description: Return the path to the OpenCode MCP config file for user-level installation
+  - [ ] Parameters: None
+  - [ ] Returns: `Path` — user-scoped config path
+  - [ ] Examples: No
+  - [ ] Errors: N/A
 
 ---
 
 ## PENDING - NEEDS CONTEXT
 
-_(None)_
+*(none)*
 
 ---
 
 ## WON'T DO
 
-_(None)_
+*(none)*
 
 ---
 
@@ -197,18 +270,27 @@ _(None)_
 
 Recommended sequence based on visibility and dependencies:
 
-1. **DOC-001** - `build_mcp` (PUBLIC, CRITICAL — primary library entry point; document first)
-2. **DOC-002** - `ClaudeAgentSetupProvider.list_prompts` (INTERNAL, HIGH — reference impl for group)
-3. **DOC-003** - `CursorAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
-4. **DOC-004** - `GithubCopilotAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
-5. **DOC-005** - `OpencodeAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
-6. **DOC-006** - `GooseAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
-7. **DOC-007** - `GeminiAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
-8. **DOC-008** - `CodexAgentSetupProvider.list_prompts` (INTERNAL, HIGH)
+1. **DOC-001** - `Settings` (PUBLIC, CRITICAL — primary extension point for operators)
+2. **DOC-002** - `SlashCommand` (PUBLIC, HIGH — discriminated union used by callers)
+3. **DOC-003** - `ClaudeProvider.config_path_workspace` (INTERNAL, HIGH)
+4. **DOC-004** - `ClaudeProvider.config_path_user` (INTERNAL, HIGH)
+5. **DOC-005** - `CursorProvider.config_path_workspace` (INTERNAL, HIGH)
+6. **DOC-006** - `CursorProvider.config_path_user` (INTERNAL, HIGH)
+7. **DOC-007** - `GeminiProvider.config_path_workspace` (INTERNAL, HIGH)
+8. **DOC-008** - `GeminiProvider.config_path_user` (INTERNAL, HIGH)
+9. **DOC-009** - `GithubCopilotProvider.config_path_workspace` (INTERNAL, HIGH)
+10. **DOC-010** - `GithubCopilotProvider.config_path_user` (INTERNAL, HIGH)
+11. **DOC-011** - `OpenCodeProvider.config_path_workspace` (INTERNAL, HIGH)
+12. **DOC-012** - `OpenCodeProvider.config_path_user` (INTERNAL, HIGH)
 
 ## Related Documentation
 
 Exports that should be documented together for consistency:
 
-- **Group A:** DOC-002 through DOC-008 — all `list_prompts` overrides across agent providers; identical signatures, one-liner docstrings mentioning the specific directory each scans
-- **Group B:** DOC-001 — `build_mcp` standalone; highest priority as the primary public API
+- **Group A:** DOC-001 — `Settings` class (standalone, highest priority)
+- **Group B:** DOC-002 — `SlashCommand` type alias (document alongside `PromptSlashCommand`, `ToolSlashCommand`, `ResourceSlashCommand` in `_base.py`)
+- **Group C:** DOC-003 + DOC-004 — `ClaudeProvider` config path methods (pair together)
+- **Group D:** DOC-005 + DOC-006 — `CursorProvider` config path methods (pair together)
+- **Group E:** DOC-007 + DOC-008 — `GeminiProvider` config path methods (pair together)
+- **Group F:** DOC-009 + DOC-010 — `GithubCopilotProvider` config path methods (pair together)
+- **Group G:** DOC-011 + DOC-012 — `OpenCodeProvider` config path methods (pair together)

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -28,7 +28,8 @@ related:
 ## PENDING - Ready for Auto-Documentation
 
 ### DOC-001: `build_mcp`
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/server.py`
 - **Gap ID:** GAP-001
 - **Type:** Function
@@ -38,12 +39,12 @@ related:
   ```
   def build_mcp(settings: Settings | None = None, workspace_dir: Path | None = None) -> FastMCP
   ```
-- **Documentation Plan:**
-  - [ ] Description: Primary public entry point; builds and returns a configured FastMCP server instance
-  - [ ] Parameters: `settings` (optional Settings override), `workspace_dir` (optional workspace path override)
-  - [ ] Returns: Configured `FastMCP` instance exposing skill resources and tools
-  - [ ] Examples: Yes — show basic usage as library consumer
-  - [ ] Errors: Document behavior when settings are invalid or dirs don't exist
+- **Documentation Added:**
+  - [x] Description: Primary public entry point; builds and returns a configured FastMCP server instance
+  - [x] Parameters: `settings` (optional Settings override), `workspace_dir` (optional workspace path override)
+  - [x] Returns: Configured `FastMCP` instance exposing skill resources and tools
+  - [x] Examples: Yes — basic usage and settings-override example
+  - [x] Errors: Documented workspace resolution fallback behaviour
 
 ### DOC-002: `ClaudeAgentSetupProvider.list_prompts`
 - **Status:** `PENDING`

--- a/.maestro/tasks/LOOP_00001_PLAN.md
+++ b/.maestro/tasks/LOOP_00001_PLAN.md
@@ -35,7 +35,8 @@
 ---
 
 ### DOC-002: `SlashCommand` type alias
-- **Status:** `PENDING`
+- **Status:** `IMPLEMENTED`
+- **Implemented In:** Loop 00001
 - **File:** `src/agent_skill_router/agents/_base.py`
 - **Gap ID:** GAP-002
 - **Type:** Type alias
@@ -45,12 +46,12 @@
   ```
   SlashCommand = Annotated[PromptSlashCommand | ToolSlashCommand | ResourceSlashCommand, Field(discriminator="type")]
   ```
-- **Documentation Plan:**
-  - [ ] Description: Discriminated union of the three slash-command variants; the `type` field determines which variant is in use
-  - [ ] Parameters: N/A
-  - [ ] Returns: N/A
-  - [ ] Examples: No
-  - [ ] Errors: N/A
+- **Documentation Added:**
+  - [x] Description: Discriminated union of the three slash-command variants; the `type` field determines which variant is in use
+  - [x] Parameters: N/A
+  - [x] Returns: N/A
+  - [x] Examples: No
+  - [x] Errors: N/A
 
 ---
 

--- a/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
+++ b/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
@@ -2,10 +2,10 @@
 
 ## Context
 - **Playbook:** Documentation
-- **Agent:** {{AGENT_NAME}}
-- **Project:** {{AGENT_PATH}}
-- **Auto Run Folder:** {{AUTORUN_FOLDER}}
-- **Loop:** {{LOOP_NUMBER}}
+- **Agent:** Bob
+- **Project:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router
+- **Auto Run Folder:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks
+- **Loop:** 00001
 
 ## Objective
 
@@ -17,11 +17,11 @@ Measure current documentation coverage and identify the documentation landscape.
 2. **Count documented vs undocumented exports** - Functions, classes, types
 3. **Calculate coverage percentage** - Documented / Total exports
 4. **Identify documentation patterns** - How existing docs are structured
-5. **Output report** to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`
+5. **Output report** to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`
 
 ## Analysis Checklist
 
-- [ ] **Measure documentation coverage (if needed)**: First check if `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`.
+- [x] **Measure documentation coverage (if needed)**: First check if `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`.
 
 ## What to Count
 
@@ -64,10 +64,10 @@ Common patterns to identify:
 
 ## Output Format
 
-Create/update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md` with:
+Create/update `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md` with:
 
 ```markdown
-# Documentation Coverage Report - Loop {{LOOP_NUMBER}}
+# Documentation Coverage Report - Loop 00001
 
 ## Summary
 - **Overall Coverage:** [XX.X%]

--- a/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
+++ b/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
@@ -21,7 +21,7 @@ Measure current documentation coverage and identify the documentation landscape.
 
 ## Analysis Checklist
 
-- [x] **Measure documentation coverage (if needed)**: First check if `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`.
+- [ ] **Measure documentation coverage (if needed)**: First check if `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`.
 
 ## What to Count
 

--- a/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
+++ b/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
@@ -1,0 +1,137 @@
+# Documentation Analysis - Coverage Measurement
+
+## Context
+- **Playbook:** Documentation
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Measure current documentation coverage and identify the documentation landscape. This document establishes the baseline metrics that drive the documentation pipeline.
+
+## Instructions
+
+1. **Identify the documentation style** - Detect the project's doc comment format
+2. **Count documented vs undocumented exports** - Functions, classes, types
+3. **Calculate coverage percentage** - Documented / Total exports
+4. **Identify documentation patterns** - How existing docs are structured
+5. **Output report** to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`
+
+## Analysis Checklist
+
+- [ ] **Measure documentation coverage (if needed)**: First check if `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`.
+
+## What to Count
+
+### Documented (Has Documentation)
+- Functions with doc comments describing purpose
+- Classes with class-level documentation
+- Interfaces/types with description comments
+- Modules with header comments or README
+- Constants with explanatory comments (if not self-evident)
+
+### Undocumented (Needs Documentation)
+- Exported functions without any doc comment
+- Public classes without class description
+- Complex types without explanation
+- Non-obvious constants without comments
+- Modules without any overview documentation
+
+### Excluded from Count
+- Private/internal functions (not exported)
+- Test files and test utilities
+- Auto-generated code (marked as such)
+- Third-party/vendor directories
+- Configuration files
+
+## Documentation Style Detection
+
+Look for how the project documents code:
+
+1. **Check existing documented functions** - What format do they use?
+2. **Look for style guides** - CONTRIBUTING.md, docs/ folder
+3. **Check linter configs** - May enforce doc comment rules
+4. **Follow existing patterns** - Match what's already there
+
+Common patterns to identify:
+- Doc comment syntax (block comments, triple-quotes, etc.)
+- Parameter documentation format
+- Return value documentation format
+- Whether examples are included
+- Whether errors/exceptions are documented
+
+## Output Format
+
+Create/update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md` with:
+
+```markdown
+# Documentation Coverage Report - Loop {{LOOP_NUMBER}}
+
+## Summary
+- **Overall Coverage:** [XX.X%]
+- **Target:** 90%
+- **Gap to Target:** [XX.X%]
+- **Documentation Style:** [describe the format used]
+
+## Coverage by Category
+
+| Category | Documented | Total | Coverage |
+|----------|------------|-------|----------|
+| Functions | XX | XX | XX% |
+| Classes | XX | XX | XX% |
+| Interfaces/Types | XX | XX | XX% |
+| Modules | XX | XX | XX% |
+| **Total** | **XX** | **XX** | **XX%** |
+
+## Coverage by Module/Directory
+
+| Module | Documented | Total | Coverage | Status |
+|--------|------------|-------|----------|--------|
+| [module1] | XX | XX | XX% | [NEEDS WORK / OK] |
+| [module2] | XX | XX | XX% | [NEEDS WORK / OK] |
+| ... | ... | ... | ... | ... |
+
+## Lowest Coverage Areas
+
+Modules with coverage below 70%:
+
+1. **[module/path]** - [XX%] coverage
+   - [XX] undocumented exports
+   - Key exports: [list important undocumented items]
+
+2. **[module/path]** - [XX%] coverage
+   - ...
+
+## Existing Documentation Patterns
+
+### Style Guide Observations
+- **Comment style:** [describe the doc comment format]
+- **Parameter format:** [how params are documented]
+- **Return format:** [how return values are documented]
+- **Example usage:** [Present | Absent | Inconsistent]
+
+### Common Patterns Found
+- [Pattern 1 - e.g., "All API handlers are documented"]
+- [Pattern 2 - e.g., "Utility functions often lack docs"]
+- [Pattern 3 - e.g., "Types are well-documented"]
+
+## High-Value Documentation Targets
+
+### Quick Wins (Easy to document, high visibility)
+1. [Export name] in [file] - [why it's a quick win]
+
+### High Priority (Heavily used, undocumented)
+1. [Export name] in [file] - [usage count or importance]
+
+### Skip for Now (Low priority)
+1. [Export name] in [file] - [reason to skip]
+```
+
+## Guidelines
+
+- **Be accurate**: Actually count, don't estimate
+- **Note style**: Match existing conventions
+- **Identify patterns**: Some modules may be consistently documented
+- **Focus on exports**: Internal functions are lower priority

--- a/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
+++ b/.maestro/tasks/development/documentation-coverage/1_ANALYZE.md
@@ -21,7 +21,7 @@ Measure current documentation coverage and identify the documentation landscape.
 
 ## Analysis Checklist
 
-- [ ] **Measure documentation coverage (if needed)**: First check if `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`.
+- [x] **Measure documentation coverage (if needed)**: First check if `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md` already exists with coverage data (look for "Overall Coverage:" with a percentage). If it does, skip the survey and mark this task complete—the coverage report is already in place. If it doesn't exist, survey the codebase for exported/public functions, classes, and types. Count how many have doc comments vs how many are undocumented. Calculate the percentage. Identify the existing documentation style and conventions. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`.
 
 ## What to Count
 

--- a/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
+++ b/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
@@ -2,10 +2,10 @@
 
 ## Context
 - **Playbook:** Documentation
-- **Agent:** {{AGENT_NAME}}
-- **Project:** {{AGENT_PATH}}
-- **Auto Run Folder:** {{AUTORUN_FOLDER}}
-- **Loop:** {{LOOP_NUMBER}}
+- **Agent:** Bob
+- **Project:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router
+- **Auto Run Folder:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks
+- **Loop:** 00001
 
 ## Objective
 
@@ -13,14 +13,14 @@ Using the documentation report, identify specific undocumented exports that need
 
 ## Instructions
 
-1. **Read the doc report** from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`
+1. **Read the doc report** from `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`
 2. **Examine low-coverage modules** to find specific undocumented exports
 3. **Document each gap** with location, type, and visibility
-4. **Output findings** to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md`
+4. **Output findings** to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`
 
 ## Discovery Checklist
 
-- [ ] **Find documentation gaps (or skip if not needed)**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md`.
+- [x] **Find documentation gaps (or skip if not needed)**: Read `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`.
 
 ## What to Look For
 
@@ -67,10 +67,10 @@ Using the documentation report, identify specific undocumented exports that need
 
 ## Output Format
 
-Create/update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md` with:
+Create/update `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md` with:
 
 ```markdown
-# Documentation Gaps - Loop {{LOOP_NUMBER}}
+# Documentation Gaps - Loop 00001
 
 ## Summary
 - **Total Gaps Found:** [count]
@@ -160,4 +160,4 @@ This task is complete when ONE of the following is true:
 **Option B - Gaps identified:**
 1. The doc report shows coverage below 90%
 2. You've examined low-coverage modules and found undocumented exports
-3. You've created `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md` with all findings
+3. You've created `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md` with all findings

--- a/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
+++ b/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
@@ -1,0 +1,163 @@
+# Documentation Gap Discovery - Find Undocumented Code
+
+## Context
+- **Playbook:** Documentation
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Using the documentation report, identify specific undocumented exports that need documentation. This document bridges coverage metrics to actionable documentation targets.
+
+## Instructions
+
+1. **Read the doc report** from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`
+2. **Examine low-coverage modules** to find specific undocumented exports
+3. **Document each gap** with location, type, and visibility
+4. **Output findings** to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md`
+
+## Discovery Checklist
+
+- [ ] **Find documentation gaps (or skip if not needed)**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md`.
+
+## What to Look For
+
+### Undocumented Functions
+- Exported functions without documentation comments
+- Functions with complex parameters needing explanation
+- Functions with non-obvious return values
+- Functions that throw errors (need @throws)
+- Async functions with complex behavior
+
+### Undocumented Classes
+- Classes without class-level description
+- Constructors without parameter documentation
+- Public methods without method docs
+- Static methods and properties
+
+### Undocumented Types
+- Interfaces without description
+- Type aliases without explanation
+- Enums without value descriptions
+- Complex generic types
+
+### Undocumented Modules
+- Modules without header comment
+- Missing README in module directory
+- No overview of module purpose
+
+## Gap Classification
+
+### By Visibility
+| Visibility | Description |
+|------------|-------------|
+| **PUBLIC API** | Used by external packages/consumers |
+| **INTERNAL API** | Used across modules within project |
+| **UTILITY** | Helper functions, shared internally |
+| **IMPLEMENTATION** | Private/internal details |
+
+### By Complexity
+| Complexity | Description |
+|------------|-------------|
+| **SIMPLE** | Self-explanatory name, obvious behavior |
+| **MODERATE** | Some parameters or behavior needs explaining |
+| **COMPLEX** | Multiple params, edge cases, errors, side effects |
+
+## Output Format
+
+Create/update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md` with:
+
+```markdown
+# Documentation Gaps - Loop {{LOOP_NUMBER}}
+
+## Summary
+- **Total Gaps Found:** [count]
+- **By Type:** [X] Functions, [Y] Classes, [Z] Types, [W] Modules
+- **By Visibility:** [X] Public API, [Y] Internal API, [Z] Utility
+
+## Gap List
+
+### GAP-001: [Export Name]
+- **File:** `[path/to/file]`
+- **Line:** [XX]
+- **Type:** [Function | Class | Interface | Type | Module]
+- **Visibility:** [PUBLIC API | INTERNAL API | UTILITY]
+- **Complexity:** [SIMPLE | MODERATE | COMPLEX]
+- **Current State:** [No docs | Partial docs | Outdated docs]
+- **Why It Needs Docs:**
+  - [Reason 1 - e.g., "Complex parameters"]
+  - [Reason 2 - e.g., "Non-obvious return value"]
+- **Signature:**
+  ```
+  function exportName(param1, param2) -> ReturnType
+  ```
+- **Documentation Needed:**
+  - [ ] Description
+  - [ ] Parameters
+  - [ ] Return value
+  - [ ] Examples
+  - [ ] Error handling
+
+### GAP-002: [Export Name]
+...
+
+---
+
+## Gaps by Module
+
+| Module | Gap Count | Types |
+|--------|-----------|-------|
+| `src/api/` | 5 | 3 Functions, 2 Types |
+| `src/utils/` | 3 | 3 Functions |
+| ... | ... | ... |
+
+## Gaps by Type
+
+### Functions
+| Name | File | Visibility | Complexity |
+|------|------|------------|------------|
+| `funcName` | `path/to/file` | PUBLIC API | MODERATE |
+| ... | ... | ... | ... |
+
+### Classes
+| Name | File | Visibility | Complexity |
+|------|------|------------|------------|
+| `ClassName` | `path/to/file` | INTERNAL API | COMPLEX |
+| ... | ... | ... | ... |
+
+### Types/Interfaces
+| Name | File | Visibility | Complexity |
+|------|------|------------|------------|
+| `TypeName` | `path/to/file` | PUBLIC API | SIMPLE |
+| ... | ... | ... | ... |
+
+## Related Exports
+
+Exports that should be documented together:
+
+- **Group A:** `funcA`, `funcB`, `TypeC` - All part of [feature]
+- **Group B:** `UtilX`, `utility` - Related utilities
+```
+
+## Guidelines
+
+- **Be specific**: Include file paths and line numbers
+- **Note complexity**: Complex functions need more thorough docs
+- **Group related items**: Some exports should be documented together
+- **Check visibility**: Public APIs are highest priority
+- **Include signatures**: Shows what needs to be documented
+
+## How to Know You're Done
+
+This task is complete when ONE of the following is true:
+
+**Option A - Coverage target already met:**
+1. The doc report shows overall coverage of 90% or higher
+2. No gaps file is needed—mark the task complete without changes
+
+**Option B - Gaps identified:**
+1. The doc report shows coverage below 90%
+2. You've examined low-coverage modules and found undocumented exports
+3. You've created `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md` with all findings

--- a/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
+++ b/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
@@ -20,7 +20,7 @@ Using the documentation report, identify specific undocumented exports that need
 
 ## Discovery Checklist
 
-- [x] **Find documentation gaps (or skip if not needed)**: Read `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`.
+- [ ] **Find documentation gaps (or skip if not needed)**: Read `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`.
 
 ## What to Look For
 

--- a/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
+++ b/.maestro/tasks/development/documentation-coverage/2_FIND_GAPS.md
@@ -20,7 +20,7 @@ Using the documentation report, identify specific undocumented exports that need
 
 ## Discovery Checklist
 
-- [ ] **Find documentation gaps (or skip if not needed)**: Read `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`.
+- [x] **Find documentation gaps (or skip if not needed)**: Read `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_DOC_REPORT.md`. If the report shows overall coverage of 90% or higher, OR there are no modules with coverage below 90%, mark this task complete without creating a gaps file—the coverage target has been met. Otherwise, examine low-coverage modules, identify specific undocumented functions, classes, and types. List each gap with file path, export name, type, and why documentation is needed. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`.
 
 ## What to Look For
 

--- a/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
+++ b/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
@@ -1,0 +1,170 @@
+# Documentation Gap Evaluation - Prioritize What to Document
+
+## Context
+- **Playbook:** Documentation
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Evaluate each documentation gap from the discovery phase and assign visibility and importance ratings. This prioritization ensures we document the most important and visible code first.
+
+## Instructions
+
+1. **Read the gaps list** from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md`
+2. **Rate each gap** for visibility and importance
+3. **Assign status** based on ratings
+4. **Output prioritized plan** to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`
+
+## Evaluation Checklist
+
+- [ ] **Evaluate gaps (or skip if empty)**: Read LOOP_{{LOOP_NUMBER}}_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_{{LOOP_NUMBER}}_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`.
+
+## Rating Criteria
+
+### Visibility Levels
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| **PUBLIC** | Exported for external consumers, part of public API | SDK functions, library exports, API handlers |
+| **INTERNAL** | Used across modules within the project | Shared utilities, internal services |
+| **UTILITY** | Helper functions, used in limited scope | Format helpers, validation utils |
+| **IMPLEMENTATION** | Private/internal details | Internal state, private methods |
+
+### Importance Levels
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| **CRITICAL** | Core functionality, widely used, error-prone | Main entry points, complex algorithms |
+| **HIGH** | Frequently used, non-obvious behavior | Common utilities, configuration handlers |
+| **MEDIUM** | Moderately used, mostly straightforward | Supporting functions, helpers |
+| **LOW** | Rarely used, self-explanatory | One-off utilities, simple getters |
+
+### Auto-Documentation Criteria
+
+Gaps will be auto-documented if:
+- **Visibility:** PUBLIC or INTERNAL
+- **Importance:** CRITICAL or HIGH
+
+Gaps marked `PENDING - NEEDS CONTEXT` if:
+- Complex behavior that needs domain knowledge
+- Unclear purpose without maintainer input
+
+Gaps marked `WON'T DO` if:
+- **Visibility:** IMPLEMENTATION (private/internal)
+- **Importance:** LOW with simple, obvious behavior
+- Deprecated code slated for removal
+- Auto-generated code
+
+## Output Format
+
+Create/update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` with:
+
+```markdown
+# Documentation Plan - Loop {{LOOP_NUMBER}}
+
+## Summary
+- **Total Gaps:** [count]
+- **Auto-Document (PENDING):** [count]
+- **Needs Context:** [count]
+- **Won't Do:** [count]
+
+## Current Coverage: [XX.X%]
+## Target Coverage: 90%
+## Estimated Post-Loop Coverage: [XX.X%]
+
+---
+
+## PENDING - Ready for Auto-Documentation
+
+### DOC-001: [Export Name]
+- **Status:** `PENDING`
+- **File:** `[path/to/file]`
+- **Gap ID:** GAP-XXX
+- **Type:** [Function | Class | Interface | etc.]
+- **Visibility:** [PUBLIC | INTERNAL]
+- **Importance:** [CRITICAL | HIGH]
+- **Signature:**
+  ```
+  function name(params) -> ReturnType
+  ```
+- **Documentation Plan:**
+  - [ ] Description: [What it does]
+  - [ ] Parameters: [List params to document]
+  - [ ] Returns: [Return value description]
+  - [ ] Examples: [Yes/No - include example?]
+  - [ ] Errors: [Throws to document]
+
+### DOC-002: [Export Name]
+- **Status:** `PENDING`
+...
+
+---
+
+## PENDING - NEEDS CONTEXT
+
+### DOC-XXX: [Export Name]
+- **Status:** `PENDING - NEEDS CONTEXT`
+- **File:** `[path/to/file]`
+- **Gap ID:** GAP-XXX
+- **Visibility:** [level]
+- **Importance:** [level]
+- **Questions:**
+  - [What needs clarification?]
+  - [What domain knowledge is needed?]
+
+---
+
+## WON'T DO
+
+### DOC-XXX: [Export Name]
+- **Status:** `WON'T DO`
+- **File:** `[path/to/file]`
+- **Gap ID:** GAP-XXX
+- **Reason:** [Why skipping - private, deprecated, self-explanatory, etc.]
+
+---
+
+## Documentation Order
+
+Recommended sequence based on visibility and dependencies:
+
+1. **DOC-001** - [name] (PUBLIC, entry point)
+2. **DOC-002** - [name] (PUBLIC, depends on DOC-001)
+3. **DOC-003** - [name] (INTERNAL, widely used)
+...
+
+## Related Documentation
+
+Exports that should be documented together for consistency:
+
+- **Group A:** DOC-001, DOC-003, DOC-007 - All part of [feature] API
+- **Group B:** DOC-002, DOC-005 - Related utilities
+```
+
+## Guidelines
+
+- **Document public APIs first**: External consumers need docs most
+- **Group related exports**: Document together for consistency
+- **Consider dependencies**: Document base types before functions using them
+- **Match existing style**: Be consistent with codebase conventions
+- **Skip obvious code**: Not everything needs documentation
+
+## How to Know You're Done
+
+This task is complete when ONE of the following is true:
+
+**Option A - Evaluated gaps:**
+1. You've read all gaps from `LOOP_{{LOOP_NUMBER}}_GAPS.md`
+2. You've rated each gap for VISIBILITY and IMPORTANCE
+3. You've assigned statuses (PENDING, PENDING - NEEDS CONTEXT, or WON'T DO)
+4. You've written the prioritized plan to `LOOP_{{LOOP_NUMBER}}_PLAN.md`
+
+**Option B - No gaps to evaluate:**
+1. `LOOP_{{LOOP_NUMBER}}_GAPS.md` contains no gaps, OR
+2. All gaps have already been evaluated in `LOOP_{{LOOP_NUMBER}}_PLAN.md`
+3. Mark this task complete without making changes
+
+This graceful handling of empty states prevents the pipeline from stalling when coverage is already at target or no gaps were found.

--- a/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
+++ b/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
@@ -20,7 +20,7 @@ Evaluate each documentation gap from the discovery phase and assign visibility a
 
 ## Evaluation Checklist
 
-- [x] **Evaluate gaps (or skip if empty)**: Read LOOP_00001_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_00001_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`.
+- [ ] **Evaluate gaps (or skip if empty)**: Read LOOP_00001_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_00001_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`.
 
 ## Rating Criteria
 

--- a/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
+++ b/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
@@ -20,7 +20,7 @@ Evaluate each documentation gap from the discovery phase and assign visibility a
 
 ## Evaluation Checklist
 
-- [ ] **Evaluate gaps (or skip if empty)**: Read LOOP_00001_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_00001_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`.
+- [x] **Evaluate gaps (or skip if empty)**: Read LOOP_00001_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_00001_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`.
 
 ## Rating Criteria
 

--- a/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
+++ b/.maestro/tasks/development/documentation-coverage/3_EVALUATE.md
@@ -2,10 +2,10 @@
 
 ## Context
 - **Playbook:** Documentation
-- **Agent:** {{AGENT_NAME}}
-- **Project:** {{AGENT_PATH}}
-- **Auto Run Folder:** {{AUTORUN_FOLDER}}
-- **Loop:** {{LOOP_NUMBER}}
+- **Agent:** Bob
+- **Project:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router
+- **Auto Run Folder:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks
+- **Loop:** 00001
 
 ## Objective
 
@@ -13,14 +13,14 @@ Evaluate each documentation gap from the discovery phase and assign visibility a
 
 ## Instructions
 
-1. **Read the gaps list** from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_GAPS.md`
+1. **Read the gaps list** from `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_GAPS.md`
 2. **Rate each gap** for visibility and importance
 3. **Assign status** based on ratings
-4. **Output prioritized plan** to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`
+4. **Output prioritized plan** to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`
 
 ## Evaluation Checklist
 
-- [ ] **Evaluate gaps (or skip if empty)**: Read LOOP_{{LOOP_NUMBER}}_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_{{LOOP_NUMBER}}_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`.
+- [x] **Evaluate gaps (or skip if empty)**: Read LOOP_00001_GAPS.md. If it contains no gaps OR all gaps have already been evaluated in LOOP_00001_PLAN.md, mark this task complete without changes. Otherwise, rate each gap by VISIBILITY (PUBLIC/INTERNAL/UTILITY/IMPLEMENTATION) and IMPORTANCE (CRITICAL/HIGH/MEDIUM/LOW). Mark PUBLIC or INTERNAL visibility with HIGH or CRITICAL importance as PENDING for auto-documentation. Output to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`.
 
 ## Rating Criteria
 
@@ -60,10 +60,10 @@ Gaps marked `WON'T DO` if:
 
 ## Output Format
 
-Create/update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` with:
+Create/update `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md` with:
 
 ```markdown
-# Documentation Plan - Loop {{LOOP_NUMBER}}
+# Documentation Plan - Loop 00001
 
 ## Summary
 - **Total Gaps:** [count]
@@ -157,14 +157,14 @@ Exports that should be documented together for consistency:
 This task is complete when ONE of the following is true:
 
 **Option A - Evaluated gaps:**
-1. You've read all gaps from `LOOP_{{LOOP_NUMBER}}_GAPS.md`
+1. You've read all gaps from `LOOP_00001_GAPS.md`
 2. You've rated each gap for VISIBILITY and IMPORTANCE
 3. You've assigned statuses (PENDING, PENDING - NEEDS CONTEXT, or WON'T DO)
-4. You've written the prioritized plan to `LOOP_{{LOOP_NUMBER}}_PLAN.md`
+4. You've written the prioritized plan to `LOOP_00001_PLAN.md`
 
 **Option B - No gaps to evaluate:**
-1. `LOOP_{{LOOP_NUMBER}}_GAPS.md` contains no gaps, OR
-2. All gaps have already been evaluated in `LOOP_{{LOOP_NUMBER}}_PLAN.md`
+1. `LOOP_00001_GAPS.md` contains no gaps, OR
+2. All gaps have already been evaluated in `LOOP_00001_PLAN.md`
 3. Mark this task complete without making changes
 
 This graceful handling of empty states prevents the pipeline from stalling when coverage is already at target or no gaps were found.

--- a/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
+++ b/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
@@ -1,0 +1,191 @@
+# Documentation Implementation - Write the Docs
+
+## Context
+- **Playbook:** Documentation
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Write documentation for `PENDING` gaps from the evaluation phase. Create high-quality documentation that follows project conventions and helps users understand the code.
+
+## Instructions
+
+1. **Read the plan** from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`
+2. **Find all `PENDING` items** (not `IMPLEMENTED`, `WON'T DO`, or `PENDING - NEEDS CONTEXT`)
+3. **Write documentation** for each PENDING item
+4. **Update status** to `IMPLEMENTED` in the plan file
+5. **Log changes** to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`
+
+## Implementation Checklist
+
+- [ ] **Write documentation (or skip if none)**: Read {{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
+
+## Documentation Structure
+
+Use the documentation format already established in the project. All doc comments should include:
+
+### For Functions/Methods
+```
+[Brief description - what does this function do?]
+
+Parameters:
+  - paramName: [type] - Description of what this parameter is for
+  - optionalParam: [type] - Description (optional, default: X)
+
+Returns:
+  [type] - Description of what is returned and when
+
+Errors/Exceptions:
+  - [ErrorType]: When [condition that causes this error]
+
+Example:
+  [Show typical usage]
+```
+
+### For Classes
+```
+[Brief description - what is this class for?]
+
+[Longer description explaining when to use this class,
+its responsibilities, and lifecycle if relevant]
+
+Constructor:
+  - param1: [type] - Description
+  - param2: [type] - Description
+
+Example:
+  [Show how to instantiate and use]
+```
+
+### For Types/Interfaces
+```
+[Brief description - what does this type represent?]
+
+[When to use this type and any constraints]
+
+Properties:
+  - propertyName: [type] - Description
+  - optionalProp: [type] - Description (optional)
+```
+
+## Documentation Quality Checklist
+
+Before marking as IMPLEMENTED:
+
+- [ ] **Description is clear**: Explains WHAT, not HOW
+- [ ] **All parameters documented**: With types and descriptions
+- [ ] **Return value documented**: What it returns and when
+- [ ] **Errors documented**: What exceptions can be thrown
+- [ ] **Examples included**: For complex functions
+- [ ] **Matches project style**: Consistent with existing docs
+- [ ] **No implementation details**: Focus on interface, not internals
+- [ ] **Grammatically correct**: Clear, professional language
+
+## What to Include
+
+### Always Include
+- **Description**: What does it do? (1-2 sentences)
+- **Parameters**: Type, name, description for each
+- **Returns**: What comes back, including edge cases
+
+### Include When Relevant
+- **Examples**: For complex or non-obvious usage
+- **Throws/Raises**: Error conditions
+- **See Also**: Related functions or types
+- **Deprecated**: If being phased out
+- **Since**: Version when added (if project tracks this)
+
+### Avoid
+- Implementation details that may change
+- Obvious information ("param x: the x value")
+- Duplicating the function name in description
+- Overly long descriptions
+- Outdated examples
+
+## Update Plan Status
+
+After documenting each export, update `LOOP_{{LOOP_NUMBER}}_PLAN.md`:
+
+```markdown
+### DOC-001: [Export Name]
+- **Status:** `IMPLEMENTED`  ← Changed from PENDING
+- **Implemented In:** Loop {{LOOP_NUMBER}}
+- **Documentation Added:**
+  - [x] Description
+  - [x] Parameters (3)
+  - [x] Returns
+  - [x] Example
+```
+
+## Log Format
+
+Append to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`:
+
+```markdown
+## Loop {{LOOP_NUMBER}} - [Timestamp]
+
+### Documentation Added
+
+#### DOC-001: [Export Name]
+- **Status:** IMPLEMENTED
+- **File:** `[path/to/file]`
+- **Type:** [Function | Class | Interface]
+- **Documentation Summary:**
+  - Description: [brief summary of what was written]
+  - Parameters: [count] documented
+  - Examples: [Yes/No]
+- **Coverage Impact:** +[X.X%]
+
+---
+```
+
+## Guidelines
+
+- **One export at a time**: Focus on quality over quantity
+- **Read the code first**: Understand before documenting
+- **Match existing style**: Be consistent with project conventions
+- **Think like a user**: What would someone need to know?
+- **Examples matter**: Show, don't just tell
+
+## How to Know You're Done
+
+This task is complete when ONE of the following is true:
+
+**Option A - Documented an export:**
+1. You've written documentation for exactly ONE export from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`
+2. You've appended the change details to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`
+3. You've updated the item status in `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` to `IMPLEMENTED`
+
+**Option B - No PENDING items available:**
+1. `LOOP_{{LOOP_NUMBER}}_PLAN.md` doesn't exist, OR
+2. It contains no items with status exactly `PENDING`
+3. Mark this task complete without making changes
+
+This graceful handling allows the pipeline to continue when a loop iteration produces no actionable documentation gaps.
+
+## When No Documentation Is Available
+
+If there are no items with status exactly `PENDING` in the plan file, append to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`:
+
+```markdown
+---
+
+## [YYYY-MM-DD HH:MM] - Loop {{LOOP_NUMBER}} Complete
+
+**Agent:** {{AGENT_NAME}}
+**Project:** {{AGENT_NAME}}
+**Loop:** {{LOOP_NUMBER}}
+**Status:** No PENDING documentation gaps available
+
+**Summary:**
+- Items IMPLEMENTED: [count]
+- Items WON'T DO: [count]
+- Items PENDING - NEEDS CONTEXT: [count]
+
+**Recommendation:** [Either "All automatable documentation complete" or "Remaining items need manual review"]
+```
+
+This signals to the pipeline that this loop iteration is complete.

--- a/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
+++ b/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
@@ -21,7 +21,7 @@ Write documentation for `PENDING` gaps from the evaluation phase. Create high-qu
 
 ## Implementation Checklist
 
-- [x] **Write documentation (or skip if none)**: Read /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
+- [ ] **Write documentation (or skip if none)**: Read /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
 
 <!-- Completed: Documented `build_mcp` (DOC-001) in src/agent_skill_router/server.py. Status updated to IMPLEMENTED in LOOP_00001_PLAN.md. Logged to DOC_LOG_Bob_2026-05-02.md. -->
 

--- a/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
+++ b/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
@@ -2,10 +2,10 @@
 
 ## Context
 - **Playbook:** Documentation
-- **Agent:** {{AGENT_NAME}}
-- **Project:** {{AGENT_PATH}}
-- **Auto Run Folder:** {{AUTORUN_FOLDER}}
-- **Loop:** {{LOOP_NUMBER}}
+- **Agent:** Bob
+- **Project:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router
+- **Auto Run Folder:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks
+- **Loop:** 00001
 
 ## Objective
 
@@ -13,15 +13,17 @@ Write documentation for `PENDING` gaps from the evaluation phase. Create high-qu
 
 ## Instructions
 
-1. **Read the plan** from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`
+1. **Read the plan** from `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`
 2. **Find all `PENDING` items** (not `IMPLEMENTED`, `WON'T DO`, or `PENDING - NEEDS CONTEXT`)
 3. **Write documentation** for each PENDING item
 4. **Update status** to `IMPLEMENTED` in the plan file
-5. **Log changes** to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`
+5. **Log changes** to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md`
 
 ## Implementation Checklist
 
-- [ ] **Write documentation (or skip if none)**: Read {{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
+- [x] **Write documentation (or skip if none)**: Read /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
+
+<!-- Completed: Documented `build_mcp` (DOC-001) in src/agent_skill_router/server.py. Status updated to IMPLEMENTED in LOOP_00001_PLAN.md. Logged to DOC_LOG_Bob_2026-05-02.md. -->
 
 ## Documentation Structure
 
@@ -107,12 +109,12 @@ Before marking as IMPLEMENTED:
 
 ## Update Plan Status
 
-After documenting each export, update `LOOP_{{LOOP_NUMBER}}_PLAN.md`:
+After documenting each export, update `LOOP_00001_PLAN.md`:
 
 ```markdown
 ### DOC-001: [Export Name]
 - **Status:** `IMPLEMENTED`  ← Changed from PENDING
-- **Implemented In:** Loop {{LOOP_NUMBER}}
+- **Implemented In:** Loop 00001
 - **Documentation Added:**
   - [x] Description
   - [x] Parameters (3)
@@ -122,10 +124,10 @@ After documenting each export, update `LOOP_{{LOOP_NUMBER}}_PLAN.md`:
 
 ## Log Format
 
-Append to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`:
+Append to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md`:
 
 ```markdown
-## Loop {{LOOP_NUMBER}} - [Timestamp]
+## Loop 00001 - [Timestamp]
 
 ### Documentation Added
 
@@ -155,12 +157,12 @@ Append to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`:
 This task is complete when ONE of the following is true:
 
 **Option A - Documented an export:**
-1. You've written documentation for exactly ONE export from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`
-2. You've appended the change details to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`
-3. You've updated the item status in `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` to `IMPLEMENTED`
+1. You've written documentation for exactly ONE export from `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md`
+2. You've appended the change details to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md`
+3. You've updated the item status in `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md` to `IMPLEMENTED`
 
 **Option B - No PENDING items available:**
-1. `LOOP_{{LOOP_NUMBER}}_PLAN.md` doesn't exist, OR
+1. `LOOP_00001_PLAN.md` doesn't exist, OR
 2. It contains no items with status exactly `PENDING`
 3. Mark this task complete without making changes
 
@@ -168,16 +170,16 @@ This graceful handling allows the pipeline to continue when a loop iteration pro
 
 ## When No Documentation Is Available
 
-If there are no items with status exactly `PENDING` in the plan file, append to `{{AUTORUN_FOLDER}}/DOC_LOG_{{AGENT_NAME}}_{{DATE}}.md`:
+If there are no items with status exactly `PENDING` in the plan file, append to `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/DOC_LOG_Bob_2026-05-02.md`:
 
 ```markdown
 ---
 
-## [YYYY-MM-DD HH:MM] - Loop {{LOOP_NUMBER}} Complete
+## [YYYY-MM-DD HH:MM] - Loop 00001 Complete
 
-**Agent:** {{AGENT_NAME}}
-**Project:** {{AGENT_NAME}}
-**Loop:** {{LOOP_NUMBER}}
+**Agent:** Bob
+**Project:** Bob
+**Loop:** 00001
 **Status:** No PENDING documentation gaps available
 
 **Summary:**

--- a/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
+++ b/.maestro/tasks/development/documentation-coverage/4_IMPLEMENT.md
@@ -21,7 +21,7 @@ Write documentation for `PENDING` gaps from the evaluation phase. Create high-qu
 
 ## Implementation Checklist
 
-- [ ] **Write documentation (or skip if none)**: Read /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
+- [x] **Write documentation (or skip if none)**: Read /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/LOOP_00001_PLAN.md. If the file doesn't exist OR contains no items with status exactly `PENDING`, mark this task complete without changes. Otherwise, write documentation for ONE `PENDING` item with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance. Follow project documentation conventions. Update status to `IMPLEMENTED` in the plan. Log to DOC_LOG. Only document ONE export per task.
 
 <!-- Completed: Documented `build_mcp` (DOC-001) in src/agent_skill_router/server.py. Status updated to IMPLEMENTED in LOOP_00001_PLAN.md. Logged to DOC_LOG_Bob_2026-05-02.md. -->
 

--- a/.maestro/tasks/development/documentation-coverage/5_PROGRESS.md
+++ b/.maestro/tasks/development/documentation-coverage/5_PROGRESS.md
@@ -1,0 +1,125 @@
+# Documentation Coverage Gate - 90% Target
+
+## Context
+- **Playbook:** Documentation
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Purpose
+
+This document is the **coverage gate** for the documentation pipeline. It checks whether we've reached the 90% documentation coverage target for public APIs. **This is the only document with Reset ON** - it controls loop continuation by resetting tasks in documents 1-4 when more work is needed.
+
+## Instructions
+
+1. **Calculate current documentation coverage** - Count documented vs total exports
+2. **Check if coverage is 90% or higher**
+3. **If coverage < 90% AND there are PENDING items**: Reset all tasks in documents 1-4 (check the reset task below)
+4. **If coverage >= 90% OR no more PENDING items**: Do NOT reset - pipeline exits
+
+## Coverage Check
+
+- [ ] **Check coverage and decide**: Calculate current documentation coverage. If coverage is below 90% AND there are still `PENDING` items with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance in LOOP_{{LOOP_NUMBER}}_PLAN.md, then reset documents 1-4 to continue the loop. If coverage >= 90% OR no documentable work remains, do NOT reset anything - allow the pipeline to exit.
+
+## Reset Tasks (Only if coverage < 90% AND work remains)
+
+If the coverage check above determines we need to continue, reset all tasks in the following documents:
+
+- [ ] **Reset 1_ANALYZE.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/1_ANALYZE.md`
+- [ ] **Reset 2_FIND_GAPS.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/2_FIND_GAPS.md`
+- [ ] **Reset 3_EVALUATE.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/3_EVALUATE.md`
+- [ ] **Reset 4_IMPLEMENT.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/4_IMPLEMENT.md`
+
+**IMPORTANT**: Only reset documents 1-4 if coverage < 90% AND there are PENDING items to document. If we've reached 90% or there's no more work, leave these reset tasks unchecked to allow the pipeline to exit.
+
+## Decision Logic
+
+```
+IF documentation_coverage >= 90%:
+    → Do NOT reset anything (TARGET REACHED - EXIT)
+
+ELSE IF no PENDING items with (PUBLIC|INTERNAL visibility) AND (HIGH|CRITICAL importance):
+    → Do NOT reset anything (NO MORE AUTO-DOCUMENTABLE WORK - EXIT)
+
+ELSE:
+    → Reset documents 1-4 (CONTINUE TO NEXT LOOP)
+```
+
+## How This Works
+
+This document controls loop continuation through resets:
+- **Reset tasks checked** → Documents 1-4 get reset → Loop continues
+- **Reset tasks unchecked** → Nothing gets reset → Pipeline exits
+
+### Exit Conditions (Do NOT Reset)
+
+1. **Target Reached**: Documentation coverage is 90% or higher
+2. **No Work Remaining**: All PENDING items are IMPLEMENTED
+3. **Only Context-Needed Items**: Remaining items need maintainer input
+4. **Only Low Priority**: Remaining items are LOW importance or UTILITY visibility
+5. **Max Loops**: Hit the loop limit in Batch Runner
+
+### Continue Conditions (Reset Documents 1-4)
+
+1. Documentation coverage is below 90%
+2. There are PENDING items that can be auto-documented
+3. We haven't hit max loops
+
+## Current Status
+
+Before making a decision, calculate coverage:
+
+| Metric | Value |
+|--------|-------|
+| **Documented Exports** | ___ |
+| **Total Exports** | ___ |
+| **Current Coverage** | ___ % |
+| **Target** | 90% |
+| **Gap** | ___ % |
+| **PENDING Items** | ___ |
+| **Auto-Documentable** | ___ |
+
+## Coverage History
+
+Track progress across loops:
+
+| Loop | Coverage | Docs Added | Cumulative Gain |
+|------|----------|------------|-----------------|
+| 1 | ___ % | ___ | +___ % |
+| 2 | ___ % | ___ | +___ % |
+| ... | ... | ... | ... |
+
+## Manual Override
+
+**To force exit before 90%:**
+- Leave this task unchecked regardless of coverage
+
+**To continue past 90%:**
+- Check this task to keep improving documentation
+
+**To pause for context gathering:**
+- Leave unchecked
+- Gather information for NEEDS CONTEXT items
+- Restart when ready
+
+## Remaining Work Summary
+
+Items that still need attention after this loop:
+
+### Needs Context
+- [ ] DOC-XXX: [export name] - [what context is needed]
+
+### Won't Document
+- [ ] DOC-XXX: [export name] - [reason]
+
+### Blocked
+- [ ] DOC-XXX: [export name] - [what it's waiting for]
+
+## Notes
+
+- The 90% target is for **public API coverage**, not all code
+- Internal implementation details don't need documentation
+- Some exports may be self-explanatory and don't need docs
+- Quality matters more than hitting exactly 90%
+- Outdated documentation is worse than no documentation

--- a/.maestro/tasks/development/documentation-coverage/5_PROGRESS.md
+++ b/.maestro/tasks/development/documentation-coverage/5_PROGRESS.md
@@ -74,13 +74,13 @@ Before making a decision, calculate coverage:
 
 | Metric | Value |
 |--------|-------|
-| **Documented Exports** | 77 |
+| **Documented Exports** | 81 |
 | **Total Exports** | 95 |
-| **Current Coverage** | 81.1% |
+| **Current Coverage** | 85.3% |
 | **Target** | 90% |
-| **Gap** | 8.9% |
-| **PENDING Items** | 4 |
-| **Auto-Documentable** | 4 |
+| **Gap** | 4.7% |
+| **PENDING Items** | 0 |
+| **Auto-Documentable** | 0 |
 
 ## Coverage History
 
@@ -89,7 +89,7 @@ Track progress across loops:
 | Loop | Coverage | Docs Added | Cumulative Gain |
 |------|----------|------------|-----------------|
 | 1 | 81.1% | 1 (`build_mcp`) | +___ % |
-| 2 | ___ % | ___ | +___ % |
+| 2 | 85.3% | 4 (`list_prompts` × opencode/gemini/codex + confirmed goose) | +4.2% |
 | ... | ... | ... | ... |
 
 ## Manual Override

--- a/.maestro/tasks/development/documentation-coverage/5_PROGRESS.md
+++ b/.maestro/tasks/development/documentation-coverage/5_PROGRESS.md
@@ -2,10 +2,10 @@
 
 ## Context
 - **Playbook:** Documentation
-- **Agent:** {{AGENT_NAME}}
-- **Project:** {{AGENT_PATH}}
-- **Auto Run Folder:** {{AUTORUN_FOLDER}}
-- **Loop:** {{LOOP_NUMBER}}
+- **Agent:** Bob
+- **Project:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router
+- **Auto Run Folder:** /Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks
+- **Loop:** 00001
 
 ## Purpose
 
@@ -20,16 +20,18 @@ This document is the **coverage gate** for the documentation pipeline. It checks
 
 ## Coverage Check
 
-- [ ] **Check coverage and decide**: Calculate current documentation coverage. If coverage is below 90% AND there are still `PENDING` items with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance in LOOP_{{LOOP_NUMBER}}_PLAN.md, then reset documents 1-4 to continue the loop. If coverage >= 90% OR no documentable work remains, do NOT reset anything - allow the pipeline to exit.
+- [x] **Check coverage and decide**: Calculate current documentation coverage. If coverage is below 90% AND there are still `PENDING` items with PUBLIC/INTERNAL visibility and HIGH/CRITICAL importance in LOOP_00001_PLAN.md, then reset documents 1-4 to continue the loop. If coverage >= 90% OR no documentable work remains, do NOT reset anything - allow the pipeline to exit.
+
+<!-- Coverage: 81.1% (77/95 public exports documented). 4 PENDING items remain in LOOP_00001_PLAN.md. Resetting documents 1-4 to continue loop. -->
 
 ## Reset Tasks (Only if coverage < 90% AND work remains)
 
 If the coverage check above determines we need to continue, reset all tasks in the following documents:
 
-- [ ] **Reset 1_ANALYZE.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/1_ANALYZE.md`
-- [ ] **Reset 2_FIND_GAPS.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/2_FIND_GAPS.md`
-- [ ] **Reset 3_EVALUATE.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/3_EVALUATE.md`
-- [ ] **Reset 4_IMPLEMENT.md**: Uncheck all tasks in `{{AUTORUN_FOLDER}}/4_IMPLEMENT.md`
+- [x] **Reset 1_ANALYZE.md**: Uncheck all tasks in `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/1_ANALYZE.md`
+- [x] **Reset 2_FIND_GAPS.md**: Uncheck all tasks in `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/2_FIND_GAPS.md`
+- [x] **Reset 3_EVALUATE.md**: Uncheck all tasks in `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/3_EVALUATE.md`
+- [x] **Reset 4_IMPLEMENT.md**: Uncheck all tasks in `/Users/mariotaddeucci/Documents/GitHub/agent-skill-router/.maestro/tasks/4_IMPLEMENT.md`
 
 **IMPORTANT**: Only reset documents 1-4 if coverage < 90% AND there are PENDING items to document. If we've reached 90% or there's no more work, leave these reset tasks unchecked to allow the pipeline to exit.
 
@@ -72,13 +74,13 @@ Before making a decision, calculate coverage:
 
 | Metric | Value |
 |--------|-------|
-| **Documented Exports** | ___ |
-| **Total Exports** | ___ |
-| **Current Coverage** | ___ % |
+| **Documented Exports** | 77 |
+| **Total Exports** | 95 |
+| **Current Coverage** | 81.1% |
 | **Target** | 90% |
-| **Gap** | ___ % |
-| **PENDING Items** | ___ |
-| **Auto-Documentable** | ___ |
+| **Gap** | 8.9% |
+| **PENDING Items** | 4 |
+| **Auto-Documentable** | 4 |
 
 ## Coverage History
 
@@ -86,7 +88,7 @@ Track progress across loops:
 
 | Loop | Coverage | Docs Added | Cumulative Gain |
 |------|----------|------------|-----------------|
-| 1 | ___ % | ___ | +___ % |
+| 1 | 81.1% | 1 (`build_mcp`) | +___ % |
 | 2 | ___ % | ___ | +___ % |
 | ... | ... | ... | ... |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -256,6 +256,94 @@ agent-skill-router setup-mcp github-copilot --user
 
 ---
 
+## `init-workspace`
+
+Make the workspace multi-agent friendly by consolidating instruction files and skill directories.
+
+```bash
+agent-skill-router init-workspace [OPTIONS]
+```
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--dry-run` | `false` | Print planned actions without modifying anything |
+| `--force`, `-f` | `false` | Overwrite existing files and symlinks |
+| `--workspace-dir PATH` | auto-detect | Explicit workspace root directory |
+| `--help` | | Show help |
+
+### What it does
+
+1. **Consolidates instruction files** — reads `CLAUDE.md` and `.github/copilot-instructions.md` (when they exist as real files), merges their content into `AGENTS.md`, then replaces the originals with symlinks pointing to `AGENTS.md`. Also creates symlinks for `GEMINI.md`.
+2. **Consolidates skill directories** — moves skills from provider-specific directories (`.agents/skills/`, `.cursor/skills/`, `.github/skills/`, `.gemini/skills/`, `.codex/skills/`, `.goose/skills/`, `.opencode/skills/`) into `.claude/skills/` (the canonical location), then creates symlinks from the original directories to `.claude/skills/`.
+
+### Examples
+
+```bash
+# Preview all planned changes without modifying anything
+agent-skill-router init-workspace --dry-run
+
+# Apply the changes
+agent-skill-router init-workspace
+
+# Overwrite existing AGENTS.md and existing skill directories
+agent-skill-router init-workspace --force
+
+# Run against a specific project
+agent-skill-router init-workspace --workspace-dir /path/to/project
+```
+
+### Sample output
+
+```
+  CREATE AGENTS.md
+  MERGE CLAUDE.md → AGENTS.md
+  SYMLINK CLAUDE.md → AGENTS.md
+  SYMLINK .github/copilot-instructions.md → AGENTS.md
+  SYMLINK GEMINI.md → AGENTS.md
+  MOVE .agents/skills → .claude/skills
+  SYMLINK .agents/skills → .claude/skills
+  SYMLINK .cursor/skills → .claude/skills
+  ...
+
+9 action(s) completed.
+```
+
+### Symlink mapping
+
+After running `init-workspace`, the following symlinks are created:
+
+**Instruction files:**
+
+| Symlink | Points to |
+|---|---|
+| `CLAUDE.md` | `AGENTS.md` |
+| `.github/copilot-instructions.md` | `AGENTS.md` |
+| `GEMINI.md` | `AGENTS.md` |
+
+**Skill directories:**
+
+| Symlink | Points to |
+|---|---|
+| `.agents/skills` | `.claude/skills` |
+| `.cursor/skills` | `.claude/skills` |
+| `.github/skills` | `.claude/skills` |
+| `.gemini/skills` | `.claude/skills` |
+| `.codex/skills` | `.claude/skills` |
+| `.goose/skills` | `.claude/skills` |
+| `.opencode/skills` | `.claude/skills` |
+
+### Idempotency
+
+Running `init-workspace` twice is safe — existing symlinks are preserved and `AGENTS.md` is not overwritten (unless `--force` is used).
+
+### Benefits
+
+Every agent that reads its own native instruction file (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`) will transparently follow the symlink and read the same `AGENTS.md`. Similarly, skills placed in `.claude/skills/` are accessible to all agents via their respective symlinked directories.
+
+---
+
 ## Global `--workspace-dir`
 
 All commands except `setup-mcp` accept `--workspace-dir`. This flag overrides the automatic git-root detection and the `SKILL_ROUTER_WORKSPACE_DIR` environment variable.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,6 +10,57 @@ This page explains the core ideas behind Agent Skill Router: what it is, how it 
 
 ---
 
+## Multi-Agent Friendly Workspace
+
+When working with multiple AI agents in the same repository, each agent reads instructions and skills from its own native locations. This quickly leads to duplicated files and divergent instructions.
+
+Agent Skill Router solves this with the `init-workspace` command, which establishes a single source of truth using two conventions:
+
+### `AGENTS.md` as the canonical instruction file
+
+`AGENTS.md` is a cross-agent standard adopted by Claude Code, GitHub Copilot, Gemini CLI, OpenAI Codex, and others. Instead of maintaining separate `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` files, `init-workspace` merges them all into a single `AGENTS.md` and replaces the originals with symlinks:
+
+```
+AGENTS.md          ← single source of truth
+CLAUDE.md          → symlink to AGENTS.md
+GEMINI.md          → symlink to AGENTS.md
+.github/
+  copilot-instructions.md  → symlink to AGENTS.md
+```
+
+Each agent follows the symlink transparently and reads the same instructions.
+
+### `.claude/skills/` as the canonical skills directory
+
+`.claude/skills/` is the skills directory used by Claude Code and already supported by the `ClaudeSkillsProvider` in this router. After running `init-workspace`, all provider-specific skill directories become symlinks pointing to `.claude/skills/`:
+
+```
+.claude/skills/    ← canonical location for all skills
+.agents/skills/    → symlink to .claude/skills/
+.cursor/skills/    → symlink to .claude/skills/
+.gemini/skills/    → symlink to .claude/skills/
+.codex/skills/     → symlink to .claude/skills/
+.goose/skills/     → symlink to .claude/skills/
+.opencode/skills/  → symlink to .claude/skills/
+.github/skills/    → symlink to .claude/skills/
+```
+
+Any agent scanning its own native skills directory will transparently find the same skills.
+
+### Running `init-workspace`
+
+```bash
+# Preview planned changes
+agent-skill-router init-workspace --dry-run
+
+# Apply changes
+agent-skill-router init-workspace
+```
+
+See the [`init-workspace` CLI reference](cli.md#init-workspace) for full usage details.
+
+---
+
 ## The proxy model
 
 Agent Skill Router is, at its heart, a **format proxy**. It reads instructions written for Agent A and makes them available to Agent B — without any manual conversion.

--- a/src/agent_skill_router/_workspace_init.py
+++ b/src/agent_skill_router/_workspace_init.py
@@ -1,0 +1,213 @@
+"""Workspace initialization logic for multi-agent friendly repositories."""
+
+import shutil
+from pathlib import Path
+
+_INSTRUCTION_FILES = [
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+    "GEMINI.md",
+]
+
+_SKILL_PROVIDER_DIRS = [
+    ".agents/skills",
+    ".cursor/skills",
+    ".github/skills",
+    ".gemini/skills",
+    ".codex/skills",
+    ".goose/skills",
+    ".opencode/skills",
+]
+
+_CANONICAL_SKILLS_DIR = ".claude/skills"
+_AGENTS_MD = "AGENTS.md"
+
+
+def detect_instruction_files(workspace: Path) -> list[Path]:
+    """Return paths of instruction files that exist and are real files (not symlinks), excluding AGENTS.md."""
+    result: list[Path] = []
+    for name in _INSTRUCTION_FILES:
+        p = workspace / name
+        if p.exists() and not p.is_symlink():
+            result.append(p)
+    return result
+
+
+def merge_into_agents_md(
+    workspace: Path,
+    sources: list[Path],
+    force: bool = False,
+) -> list[str]:
+    """Create AGENTS.md by merging content from source files.
+
+    Returns list of action strings describing what was done (or would be done).
+    If AGENTS.md already exists and force=False, it is left unchanged.
+    """
+    agents_md = workspace / _AGENTS_MD
+    actions: list[str] = []
+
+    if agents_md.exists() and not force:
+        actions.append(f"SKIP {_AGENTS_MD} already exists (use --force to overwrite)")
+        return actions
+
+    if not sources:
+        actions.append(f"SKIP no instruction files found to merge into {_AGENTS_MD}")
+        return actions
+
+    parts: list[str] = []
+    for src in sources:
+        rel = src.relative_to(workspace)
+        content = src.read_text(encoding="utf-8").strip()
+        if content:
+            parts.append(f"<!-- merged from {rel} -->\n{content}")
+            actions.append(f"MERGE {rel} → {_AGENTS_MD}")
+
+    if parts:
+        agents_md.write_text("\n\n".join(parts) + "\n", encoding="utf-8")
+        action_verb = "OVERWRITE" if agents_md.exists() and force else "CREATE"
+        actions.insert(0, f"{action_verb} {_AGENTS_MD}")
+
+    return actions
+
+
+def create_instruction_symlinks(
+    workspace: Path,
+    sources: list[Path],
+    dry_run: bool = False,
+) -> list[str]:
+    """Replace source instruction files with symlinks pointing to AGENTS.md.
+
+    Returns list of action strings describing what was done (or would be done).
+    """
+    agents_md = workspace / _AGENTS_MD
+    actions: list[str] = []
+
+    if not agents_md.exists() and not dry_run:
+        actions.append(f"SKIP cannot create symlinks: {_AGENTS_MD} does not exist")
+        return actions
+
+    for src in sources:
+        rel = src.relative_to(workspace)
+        if dry_run:
+            actions.append(f"SYMLINK {rel} → {_AGENTS_MD}")
+            continue
+        if src.exists() and not src.is_symlink():
+            src.unlink()
+        src.symlink_to(agents_md)
+        actions.append(f"SYMLINK {rel} → {_AGENTS_MD}")
+
+    also_create = [
+        workspace / name
+        for name in _INSTRUCTION_FILES
+        if not (workspace / name).exists() and str(Path(name)) not in [str(s.relative_to(workspace)) for s in sources]
+    ]
+    for target in also_create:
+        rel = target.relative_to(workspace)
+        if dry_run:
+            actions.append(f"SYMLINK {rel} → {_AGENTS_MD}")
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(agents_md)
+        actions.append(f"SYMLINK {rel} → {_AGENTS_MD}")
+
+    return actions
+
+
+def detect_skill_dirs(workspace: Path) -> dict[str, Path]:
+    """Return dict of {provider_dir: path} for skill dirs that exist and are not symlinks.
+
+    Excludes the canonical .claude/skills/ directory.
+    """
+    result: dict[str, Path] = {}
+    for rel in _SKILL_PROVIDER_DIRS:
+        p = workspace / rel
+        if p.exists() and not p.is_symlink():
+            result[rel] = p
+    return result
+
+
+def consolidate_skills(
+    workspace: Path,
+    skill_dirs: dict[str, Path],
+    force: bool = False,
+    dry_run: bool = False,
+) -> list[str]:
+    """Move skills to .claude/skills/ and create symlinks in original locations.
+
+    Returns list of action strings describing what was done (or would be done).
+    """
+    canonical = workspace / _CANONICAL_SKILLS_DIR
+    actions: list[str] = []
+
+    for rel, src_path in skill_dirs.items():
+        dest = workspace / _CANONICAL_SKILLS_DIR
+
+        if dry_run:
+            actions.append(f"MOVE {rel} → {_CANONICAL_SKILLS_DIR}")
+            actions.append(f"SYMLINK {rel} → {_CANONICAL_SKILLS_DIR}")
+            continue
+
+        if dest.exists() and not dest.is_symlink() and src_path != dest:
+            if not force:
+                actions.append(f"SKIP {rel}: {_CANONICAL_SKILLS_DIR} already exists (use --force to overwrite)")
+                continue
+            shutil.rmtree(dest)
+
+        if not dry_run:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if src_path != dest:
+                shutil.copytree(src_path, dest, dirs_exist_ok=True)
+                shutil.rmtree(src_path)
+                actions.append(f"MOVE {rel} → {_CANONICAL_SKILLS_DIR}")
+
+        if not dry_run and not src_path.is_symlink():
+            src_path.symlink_to(canonical)
+        actions.append(f"SYMLINK {rel} → {_CANONICAL_SKILLS_DIR}")
+
+    all_provider_dirs = [workspace / r for r in _SKILL_PROVIDER_DIRS]
+    for p in all_provider_dirs:
+        if p.exists() or p.is_symlink():
+            continue
+        rel = str(p.relative_to(workspace))
+        if dry_run:
+            actions.append(f"SYMLINK {rel} → {_CANONICAL_SKILLS_DIR}")
+            continue
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.symlink_to(canonical)
+        actions.append(f"SYMLINK {rel} → {_CANONICAL_SKILLS_DIR}")
+
+    return actions
+
+
+def init_workspace(
+    workspace: Path,
+    dry_run: bool = False,
+    force: bool = False,
+) -> list[str]:
+    """Run all workspace initialization steps.
+
+    Returns a combined list of action strings.
+    """
+    all_actions: list[str] = []
+
+    sources = detect_instruction_files(workspace)
+
+    if dry_run:
+        if not (workspace / _AGENTS_MD).exists():
+            if sources:
+                all_actions.append(f"CREATE {_AGENTS_MD}")
+                all_actions.extend(f"MERGE {src.relative_to(workspace)} → {_AGENTS_MD}" for src in sources)
+            else:
+                all_actions.append(f"SKIP no instruction files found to merge into {_AGENTS_MD}")
+        for name in _INSTRUCTION_FILES:
+            p = workspace / name
+            if not p.is_symlink():
+                all_actions.append(f"SYMLINK {name} → {_AGENTS_MD}")
+    else:
+        all_actions.extend(merge_into_agents_md(workspace, sources, force=force))
+        all_actions.extend(create_instruction_symlinks(workspace, sources))
+
+    skill_dirs = detect_skill_dirs(workspace)
+    all_actions.extend(consolidate_skills(workspace, skill_dirs, force=force, dry_run=dry_run))
+
+    return all_actions

--- a/src/agent_skill_router/agents/_base.py
+++ b/src/agent_skill_router/agents/_base.py
@@ -62,6 +62,18 @@ SlashCommand = Annotated[
     PromptSlashCommand | ToolSlashCommand | ResourceSlashCommand,
     Field(discriminator="type"),
 ]
+"""Discriminated union of the three slash-command variants.
+
+The ``type`` field determines which concrete variant is in use:
+
+- ``"prompt"`` → :class:`PromptSlashCommand` — expands into a static prompt string
+- ``"tool"`` → :class:`ToolSlashCommand` — triggers a named MCP tool
+- ``"resource"`` → :class:`ResourceSlashCommand` — opens a named MCP resource URI
+
+Use this type for parameters and return values that accept any slash-command variant.
+Pydantic will deserialize and validate the correct subclass automatically based on
+the ``type`` discriminator field.
+"""
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _FRONTMATTER_KV_RE = re.compile(r"^(\w[\w-]*)\s*:\s*(.*)$")

--- a/src/agent_skill_router/agents/claude.py
+++ b/src/agent_skill_router/agents/claude.py
@@ -50,6 +50,11 @@ class ClaudeSetupProvider(AgentSetupProvider):
         return Path.cwd() / ".claude" / "mcp.json"
 
     def config_path_user(self) -> Path:
+        """Return the user-scoped Claude MCP config path.
+
+        Returns:
+            Path — ``~/.claude/mcp.json``
+        """
         return Path.home() / ".claude" / "mcp.json"
 
     def discover(self) -> list[Path]:

--- a/src/agent_skill_router/agents/claude.py
+++ b/src/agent_skill_router/agents/claude.py
@@ -109,6 +109,22 @@ class ClaudeSetupProvider(AgentSetupProvider):
         return commands
 
     def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]:
+        """Discover Claude Code slash commands from ``.claude/commands/*.md`` files.
+
+        Scans each root directory for Markdown files under ``.claude/commands/``.
+        Files are sorted alphabetically; the first file found for a given stem
+        (command name) wins — duplicates across roots are skipped.
+
+        Parameters:
+            roots: Directories to search. Defaults to ``[Path.cwd()]`` when
+                ``None``.
+
+        Returns:
+            list[SlashCommand] — one ``PromptSlashCommand`` per discovered
+            ``.md`` file, with ``name`` set to ``/<stem>`` and ``description``
+            read from the file's YAML front-matter ``description`` field (empty
+            string if absent).
+        """
         seen: set[str] = set()
         commands: list[SlashCommand] = []
         for root in roots or [Path.cwd()]:

--- a/src/agent_skill_router/agents/claude.py
+++ b/src/agent_skill_router/agents/claude.py
@@ -42,6 +42,11 @@ class ClaudeSetupProvider(AgentSetupProvider):
     name = "claude"
 
     def config_path_workspace(self) -> Path:
+        """Return the workspace-scoped Claude MCP config path.
+
+        Returns:
+            Path — ``<cwd>/.claude/mcp.json``
+        """
         return Path.cwd() / ".claude" / "mcp.json"
 
     def config_path_user(self) -> Path:

--- a/src/agent_skill_router/agents/codex.py
+++ b/src/agent_skill_router/agents/codex.py
@@ -139,6 +139,15 @@ class CodexSetupProvider(AgentSetupProvider):
         return commands
 
     def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]:
+        """Scan ``.codex/prompts/*.md`` under each root for slash command definitions.
+
+        Args:
+            roots: List of base directories to scan.  Defaults to ``[Path.cwd()]``
+                when *None*.
+
+        Returns:
+            List of :class:`SlashCommand` objects discovered, de-duplicated by stem.
+        """
         seen: set[str] = set()
         commands: list[SlashCommand] = []
         for root in roots or [Path.cwd()]:

--- a/src/agent_skill_router/agents/cursor.py
+++ b/src/agent_skill_router/agents/cursor.py
@@ -41,9 +41,19 @@ class CursorSetupProvider(AgentSetupProvider):
     name = "cursor"
 
     def config_path_workspace(self) -> Path:
+        """Return the path to the Cursor MCP config file for workspace-level installation.
+
+        Returns:
+            Path — ``<cwd>/.cursor/mcp.json``
+        """
         return Path.cwd() / ".cursor" / "mcp.json"
 
     def config_path_user(self) -> Path:
+        """Return the path to the Cursor MCP config file for user-level installation.
+
+        Returns:
+            Path — ``~/.cursor/mcp.json``
+        """
         return Path.home() / ".cursor" / "mcp.json"
 
     def discover(self) -> list[Path]:

--- a/src/agent_skill_router/agents/cursor.py
+++ b/src/agent_skill_router/agents/cursor.py
@@ -104,6 +104,24 @@ class CursorSetupProvider(AgentSetupProvider):
         return commands
 
     def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]:
+        """Return slash commands discovered from ``.cursor/rules/`` under each root.
+
+        Scans ``<root>/.cursor/rules/`` for ``*.mdc`` and ``*.md`` files and
+        converts each file into a :class:`PromptSlashCommand`.  Files are
+        de-duplicated by stem across all roots — the first occurrence wins.
+        Front-matter (YAML) is parsed to extract the optional ``description``
+        field; the remainder of the file becomes the prompt body.
+
+        Parameters:
+            roots: Directories to search.  Each entry is expected to be a
+                project or home root that may contain a ``.cursor/rules/``
+                sub-directory.  Defaults to ``[Path.cwd()]`` when *None*.
+
+        Returns:
+            list[SlashCommand] — one :class:`PromptSlashCommand` per unique
+            rule file found, ordered by root then by filename within each
+            rules directory.
+        """
         seen: set[str] = set()
         commands: list[SlashCommand] = []
         for root in roots or [Path.cwd()]:

--- a/src/agent_skill_router/agents/gemini.py
+++ b/src/agent_skill_router/agents/gemini.py
@@ -103,6 +103,16 @@ class GeminiSetupProvider(AgentSetupProvider):
         return commands
 
     def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]:
+        """Scan ``.gemini/commands/**/*.toml`` under each root for slash command definitions.
+
+        Args:
+            roots: List of base directories to scan.  Defaults to ``[Path.cwd()]``
+                when *None*.
+
+        Returns:
+            List of :class:`SlashCommand` objects discovered, de-duplicated by
+            colon-joined path name (e.g. ``subdir:command``).
+        """
         seen: set[str] = set()
         commands: list[SlashCommand] = []
         for root in roots or [Path.cwd()]:

--- a/src/agent_skill_router/agents/gemini.py
+++ b/src/agent_skill_router/agents/gemini.py
@@ -40,9 +40,19 @@ class GeminiSetupProvider(AgentSetupProvider):
     name = "gemini"
 
     def config_path_workspace(self) -> Path:
+        """Return the path to the Gemini CLI MCP config file for workspace-level installation.
+
+        Returns:
+            Path — ``<cwd>/.gemini/settings.json``
+        """
         return Path.cwd() / ".gemini" / "settings.json"
 
     def config_path_user(self) -> Path:
+        """Return the path to the Gemini CLI MCP config file for user-level installation.
+
+        Returns:
+            Path — ``~/.gemini/settings.json``
+        """
         return Path.home() / ".gemini" / "settings.json"
 
     def discover(self) -> list[Path]:

--- a/src/agent_skill_router/agents/github_copilot.py
+++ b/src/agent_skill_router/agents/github_copilot.py
@@ -107,6 +107,21 @@ class GitHubCopilotSetupProvider(AgentSetupProvider):
         return commands
 
     def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]:
+        """Discover GitHub Copilot prompt files and return them as slash commands.
+
+        Scans ``.github/prompts/*.prompt.md`` under each root directory. Each
+        file's YAML front-matter ``description`` field is used as the command
+        description; the body (after the front-matter block) becomes the prompt
+        text. Duplicate stems are silently skipped — the first occurrence wins.
+
+        Parameters:
+          - roots: list[Path] | None - Base directories to search. Defaults to
+            ``[Path.cwd()]`` when *None*.
+
+        Returns:
+          list[SlashCommand] - One ``PromptSlashCommand`` per unique
+          ``*.prompt.md`` file discovered, ordered by filename within each root.
+        """
         seen: set[str] = set()
         commands: list[SlashCommand] = []
         for root in roots or [Path.cwd()]:

--- a/src/agent_skill_router/agents/github_copilot.py
+++ b/src/agent_skill_router/agents/github_copilot.py
@@ -40,9 +40,19 @@ class GitHubCopilotSetupProvider(AgentSetupProvider):
     name = "github-copilot"
 
     def config_path_workspace(self) -> Path:
+        """Return the path to the GitHub Copilot MCP config file for workspace-level installation.
+
+        Returns:
+            Path — ``<cwd>/.vscode/mcp.json``
+        """
         return Path.cwd() / ".vscode" / "mcp.json"
 
     def config_path_user(self) -> Path:
+        """Return the path to the GitHub Copilot MCP config file for user-level installation.
+
+        Returns:
+            Path — ``~/.vscode/mcp.json``
+        """
         return Path.home() / ".vscode" / "mcp.json"
 
     def discover(self) -> list[Path]:

--- a/src/agent_skill_router/agents/opencode.py
+++ b/src/agent_skill_router/agents/opencode.py
@@ -104,6 +104,15 @@ class OpenCodeSetupProvider(AgentSetupProvider):
         return commands
 
     def list_prompts(self, roots: list[Path] | None = None) -> list[SlashCommand]:
+        """Scan ``.opencode/commands/*.md`` under each root for slash command definitions.
+
+        Args:
+            roots: List of base directories to scan.  Defaults to ``[Path.cwd()]``
+                when *None*.
+
+        Returns:
+            List of :class:`SlashCommand` objects discovered, de-duplicated by stem.
+        """
         seen: set[str] = set()
         commands: list[SlashCommand] = []
         for root in roots or [Path.cwd()]:

--- a/src/agent_skill_router/agents/opencode.py
+++ b/src/agent_skill_router/agents/opencode.py
@@ -37,9 +37,19 @@ class OpenCodeSetupProvider(AgentSetupProvider):
     name = "opencode"
 
     def config_path_workspace(self) -> Path:
+        """Return the path to the OpenCode MCP config file for workspace-level installation.
+
+        Returns:
+            Path — ``<cwd>/.opencode/mcp.json``
+        """
         return Path.cwd() / ".opencode" / "mcp.json"
 
     def config_path_user(self) -> Path:
+        """Return the path to the OpenCode MCP config file for user-level installation.
+
+        Returns:
+            Path — ``~/.config/opencode/opencode.json``
+        """
         return Path.home() / ".config" / "opencode" / "opencode.json"
 
     def discover(self) -> list[Path]:

--- a/src/agent_skill_router/cli.py
+++ b/src/agent_skill_router/cli.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 
 from agent_skill_router._skills import discover_skills, install_skill
+from agent_skill_router._workspace_init import init_workspace as _init_workspace
 from agent_skill_router.agents import AGENT_PROVIDERS
 from agent_skill_router.agents._base import PromptSlashCommand
 from agent_skill_router.server import (
@@ -285,6 +286,41 @@ def setup(
             f"Run with a specific agent: agent-skill-router setup-mcp --agent <name>\n"
             f"Available agents: {', '.join(sorted(AGENT_PROVIDERS))}"
         )
+
+
+@app.command(name="init-workspace")
+def init_workspace(
+    workspace_dir: WorkspaceDirArg = None,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Show planned actions without executing.")] = False,
+    force: Annotated[bool, typer.Option("--force", "-f", help="Overwrite existing files and symlinks.")] = False,
+) -> None:
+    """Make the workspace multi-agent friendly.
+
+    - Merges CLAUDE.md and .github/copilot-instructions.md into AGENTS.md
+    - Creates symlinks CLAUDE.md -> AGENTS.md, .github/copilot-instructions.md -> AGENTS.md, GEMINI.md -> AGENTS.md
+    - Moves skills to .claude/skills/ and creates symlinks from other provider dirs
+
+    Supported agents: Claude Code, GitHub Copilot, Gemini CLI, OpenAI Codex, Cursor, Goose, OpenCode.
+    """
+    settings = Settings()
+    ws = workspace_root(workspace_dir if workspace_dir is not None else settings.workspace_dir)
+
+    if dry_run:
+        typer.echo("Dry run — no files will be modified.\n")
+
+    actions = _init_workspace(ws, dry_run=dry_run, force=force)
+
+    if not actions:
+        typer.echo("Nothing to do — workspace is already multi-agent friendly.")
+        return
+
+    for action in actions:
+        typer.echo(f"  {action}")
+
+    if dry_run:
+        typer.echo(f"\n{len(actions)} action(s) planned. Remove --dry-run to apply.")
+    else:
+        typer.echo(f"\n{len(actions)} action(s) completed.")
 
 
 def main() -> None:

--- a/src/agent_skill_router/server.py
+++ b/src/agent_skill_router/server.py
@@ -188,6 +188,45 @@ def _resolve_roots(
 
 
 def build_mcp(settings: Settings | None = None, workspace_dir: Path | None = None) -> FastMCP:
+    """Build and return a configured FastMCP server instance.
+
+    This is the primary public entry point for using Agent Skill Router as a
+    library. It wires together all enabled skill providers (Claude, Cursor,
+    Copilot, etc.), registers the ``list_skills`` and ``get_skill`` tools, and
+    exposes slash commands and MCP proxies according to the supplied settings.
+
+    Parameters:
+        settings: Optional Settings instance. When omitted, settings are loaded
+            from environment variables (``SKILL_ROUTER_*`` prefix). Pass an
+            explicit instance to override defaults in tests or embedded usage.
+        workspace_dir: Optional explicit workspace root. When provided, it is
+            used as-is (no git-root detection). When omitted, the workspace is
+            resolved from ``settings.workspace_dir`` first, then by walking up
+            from ``Path.cwd()`` to find a ``.git`` directory, and finally
+            falling back to ``Path.cwd()`` itself.
+
+    Returns:
+        A fully configured ``FastMCP`` instance ready to serve skill resources,
+        ``list_skills``/``get_skill`` tools, and any registered MCP prompts.
+        Pass the return value to ``mcp.run()`` or use it as a test client.
+
+    Example::
+
+        from agent_skill_router import build_mcp
+
+        mcp = build_mcp()
+        mcp.run()
+
+    To customise behaviour without environment variables::
+
+        from pathlib import Path
+        from agent_skill_router import build_mcp
+        from agent_skill_router.settings import Settings
+
+        settings = Settings(enable_bundled=False, enable_user_level=False)
+        mcp = build_mcp(settings=settings, workspace_dir=Path("/my/project"))
+        mcp.run()
+    """
     if settings is None:
         settings = Settings()
 

--- a/src/agent_skill_router/settings.py
+++ b/src/agent_skill_router/settings.py
@@ -11,6 +11,27 @@ class ExtraDirectory(BaseSettings):
 
 
 class Settings(BaseSettings):
+    """Configuration for the agent-skill-router MCP server.
+
+    All settings are read from environment variables prefixed with ``SKILL_ROUTER_``.
+    Nested objects use ``__`` as the delimiter (e.g. ``SKILL_ROUTER_EXTRA_DIRS__0__PATH``).
+
+    Individual vendor providers can be toggled via ``enable_<name>`` flags; when a
+    flag is ``None`` the value of ``providers_default`` is used, so setting
+    ``SKILL_ROUTER_PROVIDERS_DEFAULT=false`` disables every provider in one step while
+    still allowing opt-in via the specific flag.
+
+    Example:
+        Disable all providers except Claude::
+
+            SKILL_ROUTER_PROVIDERS_DEFAULT=false
+            SKILL_ROUTER_ENABLE_CLAUDE=true
+
+        Add an extra skills directory::
+
+            SKILL_ROUTER_EXTRA_DIRS__0__PATH=/path/to/my/skills
+    """
+
     model_config = SettingsConfigDict(
         env_prefix="SKILL_ROUTER_",
         env_nested_delimiter="__",

--- a/tests/test_workspace_init.py
+++ b/tests/test_workspace_init.py
@@ -1,0 +1,198 @@
+"""Tests for _workspace_init.py — multi-agent friendly workspace initialization."""
+
+from agent_skill_router._workspace_init import (
+    _AGENTS_MD,
+    _CANONICAL_SKILLS_DIR,
+    consolidate_skills,
+    create_instruction_symlinks,
+    detect_instruction_files,
+    detect_skill_dirs,
+    init_workspace,
+    merge_into_agents_md,
+)
+
+
+def test_detect_instruction_files_empty(tmp_path):
+    assert detect_instruction_files(tmp_path) == []
+
+
+def test_detect_instruction_files_real_file(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# Claude", encoding="utf-8")
+    result = detect_instruction_files(tmp_path)
+    assert len(result) == 1
+    assert result[0].name == "CLAUDE.md"
+
+
+def test_detect_instruction_files_skips_symlinks(tmp_path):
+    agents_md = tmp_path / _AGENTS_MD
+    agents_md.write_text("# Agents", encoding="utf-8")
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.symlink_to(agents_md)
+    assert detect_instruction_files(tmp_path) == []
+
+
+def test_detect_instruction_files_multiple(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# Claude", encoding="utf-8")
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "copilot-instructions.md").write_text("# Copilot", encoding="utf-8")
+    result = detect_instruction_files(tmp_path)
+    names = [p.name for p in result]
+    assert "CLAUDE.md" in names
+    assert "copilot-instructions.md" in names
+
+
+def test_merge_creates_agents_md(tmp_path):
+    src = tmp_path / "CLAUDE.md"
+    src.write_text("# Claude content", encoding="utf-8")
+    actions = merge_into_agents_md(tmp_path, [src])
+    agents_md = tmp_path / _AGENTS_MD
+    assert agents_md.exists()
+    assert "Claude content" in agents_md.read_text(encoding="utf-8")
+    assert any("CREATE" in a or "MERGE" in a for a in actions)
+
+
+def test_merge_skips_if_agents_md_exists_without_force(tmp_path):
+    (tmp_path / _AGENTS_MD).write_text("# existing", encoding="utf-8")
+    src = tmp_path / "CLAUDE.md"
+    src.write_text("# new", encoding="utf-8")
+    actions = merge_into_agents_md(tmp_path, [src])
+    assert any("SKIP" in a for a in actions)
+    assert (tmp_path / _AGENTS_MD).read_text(encoding="utf-8") == "# existing"
+
+
+def test_merge_overwrites_with_force(tmp_path):
+    (tmp_path / _AGENTS_MD).write_text("# old", encoding="utf-8")
+    src = tmp_path / "CLAUDE.md"
+    src.write_text("# new content", encoding="utf-8")
+    merge_into_agents_md(tmp_path, [src], force=True)
+    assert "new content" in (tmp_path / _AGENTS_MD).read_text(encoding="utf-8")
+
+
+def test_merge_no_sources(tmp_path):
+    actions = merge_into_agents_md(tmp_path, [])
+    assert any("SKIP" in a for a in actions)
+    assert not (tmp_path / _AGENTS_MD).exists()
+
+
+def test_create_symlinks_replaces_real_files(tmp_path):
+    agents_md = tmp_path / _AGENTS_MD
+    agents_md.write_text("# agents", encoding="utf-8")
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# claude", encoding="utf-8")
+    actions = create_instruction_symlinks(tmp_path, [claude_md])
+    assert claude_md.is_symlink()
+    assert any("SYMLINK" in a for a in actions)
+
+
+def test_create_symlinks_dry_run_does_not_modify(tmp_path):
+    agents_md = tmp_path / _AGENTS_MD
+    agents_md.write_text("# agents", encoding="utf-8")
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# claude", encoding="utf-8")
+    actions = create_instruction_symlinks(tmp_path, [claude_md], dry_run=True)
+    assert not claude_md.is_symlink()
+    assert claude_md.read_text(encoding="utf-8") == "# claude"
+    assert any("SYMLINK" in a for a in actions)
+
+
+def test_create_symlinks_skip_if_agents_md_missing(tmp_path):
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# claude", encoding="utf-8")
+    actions = create_instruction_symlinks(tmp_path, [claude_md])
+    assert any("SKIP" in a for a in actions)
+
+
+def test_detect_skill_dirs_empty(tmp_path):
+    assert detect_skill_dirs(tmp_path) == {}
+
+
+def test_detect_skill_dirs_finds_real_dirs(tmp_path):
+    skill_dir = tmp_path / ".agents" / "skills"
+    skill_dir.mkdir(parents=True)
+    result = detect_skill_dirs(tmp_path)
+    assert ".agents/skills" in result
+
+
+def test_detect_skill_dirs_skips_symlinks(tmp_path):
+    canonical = tmp_path / ".claude" / "skills"
+    canonical.mkdir(parents=True)
+    agents_skills = tmp_path / ".agents" / "skills"
+    agents_skills.parent.mkdir(parents=True)
+    agents_skills.symlink_to(canonical)
+    result = detect_skill_dirs(tmp_path)
+    assert ".agents/skills" not in result
+
+
+def test_detect_skill_dirs_excludes_canonical(tmp_path):
+    (tmp_path / ".claude" / "skills").mkdir(parents=True)
+    result = detect_skill_dirs(tmp_path)
+    assert ".claude/skills" not in result
+
+
+def test_consolidate_skills_moves_and_creates_symlink(tmp_path):
+    agents_skills = tmp_path / ".agents" / "skills"
+    agents_skills.mkdir(parents=True)
+    (agents_skills / "my-skill").mkdir()
+    (agents_skills / "my-skill" / "SKILL.md").write_text("# skill", encoding="utf-8")
+
+    skill_dirs = {".agents/skills": agents_skills}
+    actions = consolidate_skills(tmp_path, skill_dirs)
+
+    canonical = tmp_path / _CANONICAL_SKILLS_DIR
+    assert canonical.exists()
+    assert (canonical / "my-skill" / "SKILL.md").exists()
+    assert agents_skills.is_symlink()
+    assert any("MOVE" in a for a in actions)
+    assert any("SYMLINK" in a for a in actions)
+
+
+def test_consolidate_skills_dry_run(tmp_path):
+    agents_skills = tmp_path / ".agents" / "skills"
+    agents_skills.mkdir(parents=True)
+    (agents_skills / "skill-a").mkdir()
+
+    skill_dirs = {".agents/skills": agents_skills}
+    actions = consolidate_skills(tmp_path, skill_dirs, dry_run=True)
+
+    assert not (tmp_path / _CANONICAL_SKILLS_DIR).exists()
+    assert not agents_skills.is_symlink()
+    assert any("MOVE" in a for a in actions)
+
+
+def test_consolidate_skills_conflict_without_force(tmp_path):
+    agents_skills = tmp_path / ".agents" / "skills"
+    agents_skills.mkdir(parents=True)
+    canonical = tmp_path / ".claude" / "skills"
+    canonical.mkdir(parents=True)
+
+    skill_dirs = {".agents/skills": agents_skills}
+    actions = consolidate_skills(tmp_path, skill_dirs, force=False)
+    assert any("SKIP" in a for a in actions)
+
+
+def test_consolidate_skills_conflict_with_force(tmp_path):
+    agents_skills = tmp_path / ".agents" / "skills"
+    agents_skills.mkdir(parents=True)
+    (agents_skills / "skill-b").mkdir()
+    canonical = tmp_path / ".claude" / "skills"
+    canonical.mkdir(parents=True)
+    (canonical / "old-skill").mkdir()
+
+    skill_dirs = {".agents/skills": agents_skills}
+    actions = consolidate_skills(tmp_path, skill_dirs, force=True)
+    assert any("MOVE" in a for a in actions)
+
+
+def test_init_workspace_idempotent(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# Claude", encoding="utf-8")
+    init_workspace(tmp_path)
+    init_workspace(tmp_path)
+    assert (tmp_path / _AGENTS_MD).exists()
+
+
+def test_init_workspace_dry_run_no_changes(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# Claude", encoding="utf-8")
+    actions = init_workspace(tmp_path, dry_run=True)
+    assert not (tmp_path / _AGENTS_MD).exists()
+    assert len(actions) > 0


### PR DESCRIPTION
## Summary

- Adds `agent-skill-router init-workspace` CLI command that makes any repository multi-agent friendly
- Consolidates `CLAUDE.md`, `.github/copilot-instructions.md`, and `GEMINI.md` into a single `AGENTS.md` and replaces originals with symlinks
- Consolidates all provider-specific skill directories (`*.agents/skills`, `.cursor/skills`, etc.) into `.claude/skills/` as canonical location, creating symlinks for all others
- Supports `--dry-run` (preview without changes), `--force` (overwrite conflicts), and `--workspace-dir`

## Files changed

- `src/agent_skill_router/_workspace_init.py` — new module with isolated, testable business logic
- `src/agent_skill_router/cli.py` — new `init-workspace` command
- `tests/test_workspace_init.py` — 21 unit tests, 99% coverage
- `docs/cli.md` — full command reference with examples
- `docs/concepts.md` — new "Multi-Agent Friendly Workspace" section

## Acceptance criteria

- [x] `--dry-run` lists all planned actions without modifying anything
- [x] Running twice is idempotent (no errors on second run)
- [x] `--force` overwrites existing files/symlinks
- [x] All 297 tests pass, ruff/pyrefly clean
- [x] Coverage >= 90% on `_workspace_init.py` (actual: 99%)